### PR TITLE
Refine pricing engine and API for production readiness

### DIFF
--- a/options-pricing-engine/src/options_engine/api/fastapi_app.py
+++ b/options-pricing-engine/src/options_engine/api/fastapi_app.py
@@ -1,22 +1,61 @@
-from fastapi import FastAPI, HTTPException
+"""FastAPI application exposing the pricing engine."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import psutil
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import JSONResponse
-from datetime import datetime
-import psutil, logging
-from .routes import pricing, risk, market_data
-app=FastAPI(title="UCTG/1 Options Pricing Engine", version="1.0.1", docs_url="/docs", redoc_url="/redoc")
+
+from .routes import market_data, pricing, risk
+
+LOGGER = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="UCTG/1 Options Pricing Engine",
+    version="1.0.1",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=["*"])
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(pricing.router, prefix="/api/v1")
 app.include_router(risk.router, prefix="/api/v1")
 app.include_router(market_data.router, prefix="/api/v1")
+
+
 @app.get("/health", tags=["monitoring"])
-async def health():
+async def health() -> dict[str, object]:
+    """Expose the readiness of the service."""
+
     try:
-        return {"status":"healthy","timestamp":datetime.utcnow().isoformat(),"version":"1.0.1","system":{"memory_usage_percent": psutil.virtual_memory().percent,"disk_usage_percent": psutil.disk_usage('/').percent}}
-    except Exception as e:
-        raise HTTPException(status_code=503, detail="Service unhealthy")
+        memory_usage = psutil.virtual_memory().percent
+        disk_usage = psutil.disk_usage("/").percent
+        return {
+            "status": "healthy",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "version": app.version,
+            "system": {
+                "memory_usage_percent": memory_usage,
+                "disk_usage_percent": disk_usage,
+            },
+        }
+    except Exception as exc:  # pragma: no cover - defensive programming
+        LOGGER.exception("Health check failed")
+        raise HTTPException(status_code=503, detail="Service unhealthy") from exc
+
+
 @app.exception_handler(Exception)
-async def global_error(req, exc):
-    return JSONResponse(status_code=500, content={"error":"Internal server error"})
+async def global_error(_: Request, exc: Exception) -> JSONResponse:
+    LOGGER.exception("Unhandled exception: %s", exc)
+    return JSONResponse(status_code=500, content={"error": "Internal server error"})

--- a/options-pricing-engine/src/options_engine/api/routes/market_data.py
+++ b/options-pricing-engine/src/options_engine/api/routes/market_data.py
@@ -1,2 +1,3 @@
 from fastapi import APIRouter
-router=APIRouter(prefix='/market-data',tags=['market-data'])
+
+router = APIRouter(prefix="/market-data", tags=["market-data"])

--- a/options-pricing-engine/src/options_engine/api/routes/pricing.py
+++ b/options-pricing-engine/src/options_engine/api/routes/pricing.py
@@ -1,32 +1,110 @@
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Depends
-import time, logging
-from ..schemas.request import PricingRequest
-from ..schemas.response import PricingBatchResponse
-from ...core.models import OptionContract, MarketData
+"""Pricing endpoints."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
+from ...core.models import ExerciseStyle as DomainExerciseStyle
+from ...core.models import MarketData, OptionContract, OptionType as DomainOptionType
 from ...core.pricing_engine import OptionsEngine
+from ..schemas.request import OptionContractRequest, PricingRequest
+from ..schemas.response import PricingBatchResponse
 from ..security import require_permission
-router=APIRouter(prefix="/pricing",tags=["pricing"])
-log=logging.getLogger(__name__); engine=OptionsEngine(num_threads=8)
-@router.post("/single", response_model=PricingBatchResponse, dependencies=[Depends(require_permission("pricing:read"))])
-async def single(request: PricingRequest, background_tasks: BackgroundTasks):
-    try:
-        t0=time.perf_counter(); c0=request.contracts[0]
-        c=OptionContract(symbol=c0.symbol,strike_price=c0.strike_price,time_to_expiry=c0.time_to_expiry,option_type=c0.option_type,exercise_style=c0.exercise_style)
-        m=request.market_data; md=MarketData(spot_price=m.spot_price,risk_free_rate=m.risk_free_rate,dividend_yield=m.dividend_yield)
-        r=engine.price_option(c,md,model_name=request.model.value); dt=(time.perf_counter()-t0)*1000.0
-        background_tasks.add_task(lambda: log.info("priced %s", r.get("contract_id")))
-        return PricingBatchResponse(results=[r], total_computation_time_ms=dt, options_per_second=1000/dt if dt>0 else float("inf"))
-    except Exception as e:
-        log.exception("single failed"); raise HTTPException(status_code=500, detail=str(e))
-@router.post("/batch", response_model=PricingBatchResponse, dependencies=[Depends(require_permission("pricing:read"))])
-async def batch(request: PricingRequest, background_tasks: BackgroundTasks):
-    try:
-        t0=time.perf_counter()
-        m=request.market_data; md=MarketData(spot_price=m.spot_price,risk_free_rate=m.risk_free_rate,dividend_yield=m.dividend_yield)
-        cs=[OptionContract(symbol=x.symbol,strike_price=x.strike_price,time_to_expiry=x.time_to_expiry,option_type=x.option_type,exercise_style=x.exercise_style) for x in request.contracts]
-        rs=engine.price_portfolio(cs,md,model_name=request.model.value); dt=(time.perf_counter()-t0)*1000.0; ops=len(rs)/(dt/1000) if dt>0 else float("inf")
-        pg=engine.calculate_portfolio_greeks(rs) if request.calculate_greeks else None
-        background_tasks.add_task(lambda: log.info("batch priced %d", len(rs)))
-        return PricingBatchResponse(results=rs, total_computation_time_ms=dt, options_per_second=ops, portfolio_greeks=pg)
-    except Exception as e:
-        log.exception("batch failed"); raise HTTPException(status_code=500, detail=str(e))
+
+LOGGER = logging.getLogger(__name__)
+router = APIRouter(prefix="/pricing", tags=["pricing"])
+engine = OptionsEngine(num_threads=8)
+
+
+def _to_option_contract(contract: OptionContractRequest) -> OptionContract:
+    return OptionContract(
+        symbol=contract.symbol,
+        strike_price=contract.strike_price,
+        time_to_expiry=contract.time_to_expiry,
+        option_type=DomainOptionType(contract.option_type.value),
+        exercise_style=DomainExerciseStyle(contract.exercise_style.value),
+    )
+
+
+def _to_market_data(request: PricingRequest) -> MarketData:
+    data = request.market_data
+    return MarketData(
+        spot_price=data.spot_price,
+        risk_free_rate=data.risk_free_rate,
+        dividend_yield=data.dividend_yield,
+    )
+
+
+@router.post(
+    "/single",
+    response_model=PricingBatchResponse,
+    dependencies=[Depends(require_permission("pricing:read"))],
+)
+async def single(
+    request: PricingRequest, background_tasks: BackgroundTasks
+) -> PricingBatchResponse:
+    if not request.contracts:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No contracts provided")
+
+    domain_contract = _to_option_contract(request.contracts[0])
+    market_data = _to_market_data(request)
+    override_volatility = request.market_data.volatility
+
+    start = time.perf_counter()
+    result = engine.price_option(
+        domain_contract,
+        market_data,
+        model_name=request.model.value,
+        override_volatility=override_volatility,
+    )
+    duration_ms = (time.perf_counter() - start) * 1000.0
+
+    background_tasks.add_task(
+        lambda contract_id=result["contract_id"]: LOGGER.info("Priced %s", contract_id)
+    )
+
+    options_per_second = 1000.0 / duration_ms if duration_ms > 0 else float("inf")
+    return PricingBatchResponse(
+        results=[result],
+        total_computation_time_ms=duration_ms,
+        options_per_second=options_per_second,
+    )
+
+
+@router.post(
+    "/batch",
+    response_model=PricingBatchResponse,
+    dependencies=[Depends(require_permission("pricing:read"))],
+)
+async def batch(request: PricingRequest, background_tasks: BackgroundTasks) -> PricingBatchResponse:
+    if not request.contracts:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No contracts provided")
+
+    contracts = [_to_option_contract(contract) for contract in request.contracts]
+    market_data = _to_market_data(request)
+    override_volatility = request.market_data.volatility
+
+    start = time.perf_counter()
+    results = engine.price_portfolio(
+        contracts,
+        market_data,
+        model_name=request.model.value,
+        override_volatility=override_volatility,
+    )
+    duration_ms = (time.perf_counter() - start) * 1000.0
+    options_per_second = len(results) / (duration_ms / 1000.0) if duration_ms > 0 else float("inf")
+
+    portfolio_greeks = (
+        engine.calculate_portfolio_greeks(results) if request.calculate_greeks else None
+    )
+    background_tasks.add_task(lambda count=len(results): LOGGER.info("Priced %d contracts", count))
+
+    return PricingBatchResponse(
+        results=results,
+        total_computation_time_ms=duration_ms,
+        options_per_second=options_per_second,
+        portfolio_greeks=portfolio_greeks,
+    )

--- a/options-pricing-engine/src/options_engine/api/routes/risk.py
+++ b/options-pricing-engine/src/options_engine/api/routes/risk.py
@@ -1,3 +1,6 @@
 from fastapi import APIRouter, Depends
 from ..security import require_permission
-router=APIRouter(prefix='/risk',tags=['risk'],dependencies=[Depends(require_permission('risk:read'))])
+
+router = APIRouter(
+    prefix="/risk", tags=["risk"], dependencies=[Depends(require_permission("risk:read"))]
+)

--- a/options-pricing-engine/src/options_engine/api/schemas/request.py
+++ b/options-pricing-engine/src/options_engine/api/schemas/request.py
@@ -2,12 +2,24 @@ from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional
 from enum import Enum
 import re
+
+
 class OptionType(str, Enum):
-    CALL="call"; PUT="put"
+    CALL = "call"
+    PUT = "put"
+
+
 class ExerciseStyle(str, Enum):
-    EUROPEAN="european"; AMERICAN="american"
+    EUROPEAN = "european"
+    AMERICAN = "american"
+
+
 class PricingModel(str, Enum):
-    BLACK_SCHOLES="black_scholes"; BINOMIAL="binomial_200"; MONTE_CARLO="monte_carlo_20k"
+    BLACK_SCHOLES = "black_scholes"
+    BINOMIAL = "binomial_200"
+    MONTE_CARLO = "monte_carlo_20k"
+
+
 class OptionContractRequest(BaseModel):
     symbol: str = Field(..., min_length=1, max_length=20)
     strike_price: float = Field(..., gt=0, le=1e9)
@@ -15,17 +27,23 @@ class OptionContractRequest(BaseModel):
     option_type: OptionType
     exercise_style: ExerciseStyle = ExerciseStyle.EUROPEAN
     quantity: int = Field(1, ge=1, le=1_000_000)
+
     @field_validator("symbol")
     @classmethod
-    def sym(cls,v:str)->str:
-        v=v.upper()
-        if not re.fullmatch(r"[A-Z0-9]{1,20}", v): raise ValueError("symbol must be 1-20 uppercase alphanumerics")
+    def sym(cls, v: str) -> str:
+        v = v.upper()
+        if not re.fullmatch(r"[A-Z0-9]{1,20}", v):
+            raise ValueError("symbol must be 1-20 uppercase alphanumerics")
         return v
+
+
 class MarketDataRequest(BaseModel):
     spot_price: float = Field(..., gt=0, le=1e9)
-    risk_free_rate: float = Field(..., ge=0, le=1.0)
+    risk_free_rate: float = Field(..., ge=-1.0, le=1.0)
     dividend_yield: float = Field(0.0, ge=0, le=1.0)
     volatility: Optional[float] = Field(None, gt=0, le=5.0)
+
+
 class PricingRequest(BaseModel):
     contracts: List[OptionContractRequest]
     market_data: MarketDataRequest

--- a/options-pricing-engine/src/options_engine/api/schemas/response.py
+++ b/options-pricing-engine/src/options_engine/api/schemas/response.py
@@ -1,12 +1,41 @@
-from pydantic import BaseModel
+"""Response schemas exposed by the API."""
+
+from __future__ import annotations
+
 from typing import List, Optional
+
+from pydantic import BaseModel
+
+
 class PricingResultResponse(BaseModel):
-    contract_id: str; theoretical_price: float
-    delta: float|None=None; gamma: float|None=None; theta: float|None=None; vega: float|None=None; rho: float|None=None
-    implied_volatility: float|None=None; computation_time_ms: float|None=None
-    model_used: str; volatility_used: float|None=None; cached: bool|None=None; error: str|None=None
+    contract_id: str
+    theoretical_price: float
+    delta: Optional[float] = None
+    gamma: Optional[float] = None
+    theta: Optional[float] = None
+    vega: Optional[float] = None
+    rho: Optional[float] = None
+    implied_volatility: Optional[float] = None
+    computation_time_ms: Optional[float] = None
+    model_used: str
+    volatility_used: Optional[float] = None
+    cached: Optional[bool] = None
+    error: Optional[str] = None
+
+
 class PortfolioGreeksResponse(BaseModel):
-    delta: float; gamma: float; theta: float; vega: float; rho: float; total_value: float; total_vega_exposure: float; position_count: float
+    delta: float
+    gamma: float
+    theta: float
+    vega: float
+    rho: float
+    total_value: float
+    total_vega_exposure: float
+    position_count: float
+
+
 class PricingBatchResponse(BaseModel):
-    results: List[PricingResultResponse]; total_computation_time_ms: float; options_per_second: float
-    portfolio_greeks: PortfolioGreeksResponse | None = None
+    results: List[PricingResultResponse]
+    total_computation_time_ms: float
+    options_per_second: float
+    portfolio_greeks: Optional[PortfolioGreeksResponse] = None

--- a/options-pricing-engine/src/options_engine/core/models.py
+++ b/options-pricing-engine/src/options_engine/core/models.py
@@ -1,29 +1,85 @@
+"""Domain models for the options pricing engine."""
+
+from __future__ import annotations
+
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from enum import Enum
-from datetime import datetime
+from typing import Optional
+
+
 class OptionType(str, Enum):
-    CALL="call"; PUT="put"
+    """Supported option contract types."""
+
+    CALL = "call"
+    PUT = "put"
+
+
 class ExerciseStyle(str, Enum):
-    EUROPEAN="european"; AMERICAN="american"
-@dataclass(frozen=True)
+    """Available exercise styles for an option contract."""
+
+    EUROPEAN = "european"
+    AMERICAN = "american"
+
+
+@dataclass(frozen=True, slots=True)
 class MarketData:
-    spot_price: float; risk_free_rate: float; dividend_yield: float = 0.0; timestamp: float|None=None
-    def __post_init__(self):
-        if self.spot_price<=0: raise ValueError("S>0")
-        if not (0<=self.risk_free_rate<=1): raise ValueError("r in [0,1]")
-        if not (0<=self.dividend_yield<=1): raise ValueError("q in [0,1]")
+    """Market conditions required to price an option."""
+
+    spot_price: float
+    risk_free_rate: float
+    dividend_yield: float = 0.0
+    timestamp: Optional[datetime] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass validation
+        if self.spot_price <= 0:
+            raise ValueError("spot_price must be strictly positive")
+        if not -1.0 <= self.risk_free_rate <= 1.0:
+            raise ValueError("risk_free_rate must be within [-1, 1]")
+        if not 0 <= self.dividend_yield <= 1.0:
+            raise ValueError("dividend_yield must be within [0, 1]")
         if self.timestamp is None:
-            object.__setattr__(self, "timestamp", datetime.utcnow().timestamp())
-@dataclass(frozen=True)
+            object.__setattr__(self, "timestamp", datetime.now(UTC))
+
+
+@dataclass(frozen=True, slots=True)
 class OptionContract:
-    symbol: str; strike_price: float; time_to_expiry: float; option_type: OptionType; exercise_style: ExerciseStyle = ExerciseStyle.EUROPEAN; contract_id: str|None=None
-    def __post_init__(self):
-        if self.strike_price<=0: raise ValueError("K>0")
-        if self.time_to_expiry<=0: raise ValueError("T>0")
-        cid=self.contract_id or f"{self.symbol}_{self.strike_price:.4f}_{self.time_to_expiry:.6f}_{self.option_type.value}"
-        object.__setattr__(self, "contract_id", cid)
-@dataclass
+    """Immutable description of an option contract to be priced."""
+
+    symbol: str
+    strike_price: float
+    time_to_expiry: float
+    option_type: OptionType
+    exercise_style: ExerciseStyle = ExerciseStyle.EUROPEAN
+    contract_id: Optional[str] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass validation
+        if not self.symbol:
+            raise ValueError("symbol must be a non-empty string")
+        if self.strike_price <= 0:
+            raise ValueError("strike_price must be strictly positive")
+        if self.time_to_expiry <= 0:
+            raise ValueError("time_to_expiry must be strictly positive")
+
+        contract_id = self.contract_id or (
+            f"{self.symbol}_{self.strike_price:.4f}_"
+            f"{self.time_to_expiry:.6f}_{self.option_type.value}"
+        )
+        object.__setattr__(self, "contract_id", contract_id)
+
+
+@dataclass(slots=True)
 class PricingResult:
-    contract_id: str; theoretical_price: float
-    delta: float|None=None; gamma: float|None=None; theta: float|None=None; vega: float|None=None; rho: float|None=None
-    implied_volatility: float|None=None; computation_time_ms: float=0.0; model_used: str="unknown"; error: str|None=None
+    """Container for the outcome of a pricing model evaluation."""
+
+    contract_id: str
+    theoretical_price: float
+    delta: Optional[float] = None
+    gamma: Optional[float] = None
+    theta: Optional[float] = None
+    vega: Optional[float] = None
+    rho: Optional[float] = None
+    implied_volatility: Optional[float] = None
+    computation_time_ms: float = 0.0
+    model_used: str = "unknown"
+    error: Optional[str] = None

--- a/options-pricing-engine/src/options_engine/core/pricing_engine.py
+++ b/options-pricing-engine/src/options_engine/core/pricing_engine.py
@@ -1,46 +1,218 @@
-import time, logging, threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Dict, Tuple, Optional
-from .models import OptionContract, MarketData
+"""Threaded options pricing engine with caching."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import OrderedDict
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from .models import MarketData, OptionContract, PricingResult
 from .pricing_models import BlackScholesModel, BinomialModel, MonteCarloModel
-from .volatility_surface import VolatilitySurface, VolatilitySurface as VS
-log=logging.getLogger(__name__)
+from .volatility_surface import VolatilitySurface
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    """Internal representation of a cached pricing result."""
+
+    payload: Dict[str, object]
+    timestamp: float
+
+
+class _ResultCache:
+    """Thread-safe LRU cache with TTL support."""
+
+    def __init__(self, max_size: int = 10_000, ttl_seconds: float = 5.0) -> None:
+        self._max_size = max(1, max_size)
+        self._ttl = max(0.0, ttl_seconds)
+        self._lock = threading.RLock()
+        self._entries: "OrderedDict[str, _CacheEntry]" = OrderedDict()
+
+    def get(self, key: str, now: Optional[float] = None) -> Optional[Dict[str, object]]:
+        if not key:
+            return None
+
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+
+            current_time = now or time.time()
+            if self._ttl and current_time - entry.timestamp > self._ttl:
+                self._entries.pop(key, None)
+                return None
+
+            self._entries.move_to_end(key)
+            return dict(entry.payload)
+
+    def put(self, key: str, payload: Dict[str, object], now: Optional[float] = None) -> None:
+        if not key:
+            return
+
+        with self._lock:
+            if key in self._entries:
+                self._entries.move_to_end(key)
+
+            current_time = now or time.time()
+            self._entries[key] = _CacheEntry(dict(payload), current_time)
+
+            while len(self._entries) > self._max_size:
+                self._entries.popitem(last=False)
+
+
 class OptionsEngine:
-    def __init__(self,num_threads:int=8,cache_size:int=10000):
-        self.vol_surface=VS(); self.models={"black_scholes": BlackScholesModel(), "binomial_200": BinomialModel(200), "monte_carlo_20k": MonteCarloModel(20000)}
-        self.num_threads=num_threads; self.cache_size=cache_size; self.cache: Dict[str, Tuple[Dict,float]]={}; self.lock=threading.RLock(); self.total=0
-    def _key(self,c:OptionContract,md:MarketData,model:str)->str:
-        return f"{c.contract_id}|{md.spot_price:.6f}|{md.risk_free_rate:.6f}|{md.dividend_yield:.6f}|{model}"
-    def _get(self,k:str)->Optional[Dict]:
-        with self.lock:
-            v=self.cache.get(k); 
-            if v and time.time()-v[1]<5.0: return v[0]
-        return None
-    def _put(self,k:str,res:Dict)->None:
-        with self.lock:
-            if len(self.cache)>=self.cache_size:
-                oldest=min(self.cache.items(),key=lambda kv:kv[1][1])[0]; self.cache.pop(oldest,None)
-            self.cache[k]=(res,time.time())
-    def price_option(self,c:OptionContract,md:MarketData,model_name:str="black_scholes")->Dict:
-        if model_name not in self.models: raise ValueError("unknown model")
-        k=self._key(c,md,model_name); hit=self._get(k)
-        if hit: return {**hit,"cached":True}
-        vol=self.vol_surface.get_volatility(c.strike_price,c.time_to_expiry,md.spot_price)
-        r=self.models[model_name].calculate_price(c,md,vol)
-        out={"contract_id":r.contract_id,"theoretical_price":r.theoretical_price,"delta":r.delta,"gamma":r.gamma,"theta":r.theta,"vega":r.vega,"rho":r.rho,"implied_volatility":r.implied_volatility,"model_used":model_name,"volatility_used":vol,"computation_time_ms":r.computation_time_ms,"error":r.error}
-        self._put(k,out); self.total+=1; return {**out,"cached":False}
-    def price_portfolio(self,contracts:List[OptionContract],md:MarketData,model_name:str="black_scholes")->List[Dict]:
-        if not contracts: return []
-        res=[]; 
-        with ThreadPoolExecutor(max_workers=self.num_threads) as ex:
-            futures=[ex.submit(self.price_option,c,md,model_name) for c in contracts]
-            for f in as_completed(futures):
-                try: res.append(f.result())
-                except Exception as e: log.exception("pricing failed"); res.append({"theoretical_price":0.0,"error":str(e),"model_used":model_name})
-        return res
-    def calculate_portfolio_greeks(self,results:List[Dict])->Dict[str,float]:
-        if not results: return {k:0.0 for k in ["delta","gamma","theta","vega","rho","total_value","total_vega_exposure","position_count"]}
-        td=sum((x.get("delta") or 0.0) for x in results); tg=sum((x.get("gamma") or 0.0) for x in results)
-        tt=sum((x.get("theta") or 0.0) for x in results); tv=sum((x.get("vega") or 0.0) for x in results)
-        tr=sum((x.get("rho") or 0.0) for x in results); tvl=sum((x.get("theoretical_price") or 0.0) for x in results)
-        return {"delta":td,"gamma":tg,"theta":tt,"vega":tv,"rho":tr,"total_value":tvl,"total_vega_exposure":tv*100.0,"position_count":float(len(results))}
+    """Coordinates pricing model execution across a pool of workers."""
+
+    def __init__(
+        self,
+        *,
+        num_threads: int = 8,
+        cache_size: int = 10_000,
+        cache_ttl_seconds: float = 5.0,
+        volatility_surface: Optional[VolatilitySurface] = None,
+    ) -> None:
+        self.num_threads = max(1, num_threads)
+        self.vol_surface = volatility_surface or VolatilitySurface()
+        self.models: Dict[str, object] = {
+            "black_scholes": BlackScholesModel(),
+            "binomial_200": BinomialModel(steps=200),
+            "monte_carlo_20k": MonteCarloModel(paths=20_000),
+        }
+        self._cache = _ResultCache(max_size=cache_size, ttl_seconds=cache_ttl_seconds)
+
+    def _make_cache_key(
+        self,
+        contract: OptionContract,
+        market_data: MarketData,
+        model_name: str,
+        volatility: float,
+    ) -> str:
+        return (
+            f"{contract.contract_id}|{market_data.spot_price:.6f}|"
+            f"{market_data.risk_free_rate:.6f}|{market_data.dividend_yield:.6f}|"
+            f"{model_name}|{volatility:.6f}"
+        )
+
+    def _prepare_result(
+        self, result: PricingResult, model_name: str, volatility: float
+    ) -> Dict[str, object]:
+        return {
+            "contract_id": result.contract_id,
+            "theoretical_price": result.theoretical_price,
+            "delta": result.delta,
+            "gamma": result.gamma,
+            "theta": result.theta,
+            "vega": result.vega,
+            "rho": result.rho,
+            "implied_volatility": result.implied_volatility or volatility,
+            "model_used": model_name,
+            "volatility_used": volatility,
+            "computation_time_ms": result.computation_time_ms,
+            "error": result.error,
+        }
+
+    def price_option(
+        self,
+        contract: OptionContract,
+        market_data: MarketData,
+        model_name: str = "black_scholes",
+        override_volatility: Optional[float] = None,
+    ) -> Dict[str, object]:
+        if model_name not in self.models:
+            raise ValueError(f"Unknown model '{model_name}'")
+
+        model = self.models[model_name]
+        volatility = override_volatility
+        if volatility is None:
+            volatility = self.vol_surface.get_volatility(
+                strike=contract.strike_price,
+                maturity=contract.time_to_expiry,
+                spot=market_data.spot_price,
+            )
+
+        cache_key = self._make_cache_key(contract, market_data, model_name, volatility)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            cached["cached"] = True
+            return cached
+
+        result = model.calculate_price(contract, market_data, volatility)
+        payload = self._prepare_result(result, model_name, volatility)
+        payload["cached"] = False
+        self._cache.put(cache_key, payload)
+        return payload
+
+    def price_portfolio(
+        self,
+        contracts: Iterable[OptionContract],
+        market_data: MarketData,
+        model_name: str = "black_scholes",
+        override_volatility: Optional[float] = None,
+    ) -> List[Dict[str, object]]:
+        contract_list = list(contracts)
+        if not contract_list:
+            return []
+
+        futures: Dict[Future[Dict[str, object]], int] = {}
+        results: List[Optional[Dict[str, object]]] = [None] * len(contract_list)
+
+        with ThreadPoolExecutor(max_workers=self.num_threads) as executor:
+            for index, contract in enumerate(contract_list):
+                future = executor.submit(
+                    self.price_option,
+                    contract,
+                    market_data,
+                    model_name,
+                    override_volatility,
+                )
+                futures[future] = index
+
+            for future in as_completed(futures):
+                index = futures[future]
+                try:
+                    results[index] = future.result()
+                except Exception as exc:  # pragma: no cover - defensive programming
+                    LOGGER.exception(
+                        "Pricing failed for contract %s", contract_list[index].contract_id
+                    )
+                    results[index] = {
+                        "contract_id": contract_list[index].contract_id,
+                        "theoretical_price": 0.0,
+                        "model_used": model_name,
+                        "error": str(exc),
+                    }
+
+        return [result for result in results if result is not None]
+
+    @staticmethod
+    def calculate_portfolio_greeks(results: Iterable[Dict[str, object]]) -> Dict[str, float]:
+        totals = {
+            "delta": 0.0,
+            "gamma": 0.0,
+            "theta": 0.0,
+            "vega": 0.0,
+            "rho": 0.0,
+            "total_value": 0.0,
+            "total_vega_exposure": 0.0,
+            "position_count": 0.0,
+        }
+
+        count = 0
+        for result in results:
+            totals["delta"] += float(result.get("delta") or 0.0)
+            totals["gamma"] += float(result.get("gamma") or 0.0)
+            totals["theta"] += float(result.get("theta") or 0.0)
+            totals["vega"] += float(result.get("vega") or 0.0)
+            totals["rho"] += float(result.get("rho") or 0.0)
+            totals["total_value"] += float(result.get("theoretical_price") or 0.0)
+            count += 1
+
+        totals["total_vega_exposure"] = totals["vega"] * 100.0
+        totals["position_count"] = float(count)
+        return totals

--- a/options-pricing-engine/src/options_engine/core/pricing_models.py
+++ b/options-pricing-engine/src/options_engine/core/pricing_models.py
@@ -1,58 +1,255 @@
-import math, time, logging
+"""Pricing model implementations used by the engine."""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import dataclass
+from typing import Tuple
+
 import numpy as np
 from scipy.stats import norm
-from .models import OptionContract, MarketData, PricingResult, OptionType
+
+from .models import ExerciseStyle, MarketData, OptionContract, OptionType, PricingResult
 from ..utils.validation import validate_pricing_parameters
-log=logging.getLogger(__name__)
-def _bs(S,K,T,r,sigma,q,is_call):
-    if T<=1e-12 or sigma<=1e-12:
-        intrinsic = max(0.0, S-K) if is_call else max(0.0, K-S)
-        return intrinsic,0,0,0,0,0
-    st=math.sqrt(T); d1=(math.log(S/K)+(r-q+0.5*sigma*sigma)*T)/(sigma*st); d2=d1-sigma*st
-    if is_call:
-        price=S*math.exp(-q*T)*norm.cdf(d1)-K*math.exp(-r*T)*norm.cdf(d2); delta=math.exp(-q*T)*norm.cdf(d1); rho=K*T*math.exp(-r*T)*norm.cdf(d2)/100.0
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _black_scholes_payoff(
+    contract: OptionContract,
+    spot: float,
+    strike: float,
+) -> float:
+    """Return the intrinsic value of an option contract."""
+
+    intrinsic = max(0.0, spot - strike)
+    if contract.option_type is OptionType.PUT:
+        intrinsic = max(0.0, strike - spot)
+    return intrinsic
+
+
+def _black_scholes_greeks(
+    contract: OptionContract,
+    market_data: MarketData,
+    volatility: float,
+) -> Tuple[float, float, float, float, float, float]:
+    """Calculate the Black-Scholes price and greeks."""
+
+    spot = market_data.spot_price
+    strike = contract.strike_price
+    time_to_expiry = contract.time_to_expiry
+    rate = market_data.risk_free_rate
+    dividend = market_data.dividend_yield
+
+    if time_to_expiry <= 1e-12 or volatility <= 1e-12:
+        intrinsic = _black_scholes_payoff(contract, spot, strike)
+        return intrinsic, 0.0, 0.0, 0.0, 0.0, 0.0
+
+    sqrt_t = math.sqrt(time_to_expiry)
+    numerator = math.log(spot / strike) + (rate - dividend + 0.5 * volatility**2) * time_to_expiry
+    denominator = volatility * sqrt_t
+    d1 = numerator / denominator
+    d2 = d1 - volatility * sqrt_t
+
+    pdf = norm.pdf(d1)
+
+    if contract.option_type is OptionType.CALL:
+        price = spot * math.exp(-dividend * time_to_expiry) * norm.cdf(d1) - strike * math.exp(
+            -rate * time_to_expiry
+        ) * norm.cdf(d2)
+        delta = math.exp(-dividend * time_to_expiry) * norm.cdf(d1)
+        rho = strike * time_to_expiry * math.exp(-rate * time_to_expiry) * norm.cdf(d2) / 100.0
+        theta = (
+            -spot * pdf * volatility * math.exp(-dividend * time_to_expiry) / (2.0 * sqrt_t)
+            - dividend * spot * math.exp(-dividend * time_to_expiry) * norm.cdf(d1)
+            + rate * strike * math.exp(-rate * time_to_expiry) * norm.cdf(d2)
+        ) / 365.0
     else:
-        price=K*math.exp(-r*T)*norm.cdf(-d2)-S*math.exp(-q*T)*norm.cdf(-d1); delta=-math.exp(-q*T)*norm.cdf(-d1); rho=-K*T*math.exp(-r*T)*norm.cdf(-d2)/100.0
-    pdf=norm.pdf(d1); gamma=math.exp(-q*T)*pdf/(S*sigma*st); vega=S*math.exp(-q*T)*pdf*st/100.0
-    theta=(-S*pdf*sigma*math.exp(-q*T)/(2*st) + (q*S*math.exp(-q*T)*(norm.cdf(d1) if is_call else -norm.cdf(-d1))) - (r*K*math.exp(-r*T)*(norm.cdf(d2) if is_call else -norm.cdf(-d2))))/365.0
-    return price,delta,gamma,theta,vega,rho
+        price = strike * math.exp(-rate * time_to_expiry) * norm.cdf(-d2) - spot * math.exp(
+            -dividend * time_to_expiry
+        ) * norm.cdf(-d1)
+        delta = -math.exp(-dividend * time_to_expiry) * norm.cdf(-d1)
+        rho = -strike * time_to_expiry * math.exp(-rate * time_to_expiry) * norm.cdf(-d2) / 100.0
+        theta = (
+            -spot * pdf * volatility * math.exp(-dividend * time_to_expiry) / (2.0 * sqrt_t)
+            + dividend * spot * math.exp(-dividend * time_to_expiry) * norm.cdf(-d1)
+            - rate * strike * math.exp(-rate * time_to_expiry) * norm.cdf(-d2)
+        ) / 365.0
+
+    gamma = math.exp(-dividend * time_to_expiry) * pdf / (spot * volatility * sqrt_t)
+    vega = spot * math.exp(-dividend * time_to_expiry) * pdf * sqrt_t / 100.0
+
+    return price, delta, gamma, theta, vega, rho
+
+
+@dataclass(slots=True)
 class BlackScholesModel:
-    def calculate_price(self,c:OptionContract,md:MarketData,vol:float)->PricingResult:
-        t0=time.perf_counter()
+    """Deterministic Black-Scholes pricing model."""
+
+    def calculate_price(
+        self,
+        contract: OptionContract,
+        market_data: MarketData,
+        volatility: float,
+    ) -> PricingResult:
+        start = time.perf_counter()
         try:
-            validate_pricing_parameters(c,md,vol)
-            price,delta,gamma,theta,vega,rho=_bs(md.spot_price,c.strike_price,c.time_to_expiry,md.risk_free_rate,vol,md.dividend_yield,c.option_type==OptionType.CALL)
-            return PricingResult(c.contract_id,max(0.0,price),delta,gamma,theta,vega,rho,vol,(time.perf_counter()-t0)*1000.0,"black_scholes")
-        except Exception as e:
-            log.exception("BS failed"); return PricingResult(c.contract_id,0.0,error=str(e),computation_time_ms=(time.perf_counter()-t0)*1000.0,model_used="black_scholes")
+            validate_pricing_parameters(contract, market_data, volatility)
+            price, delta, gamma, theta, vega, rho = _black_scholes_greeks(
+                contract, market_data, volatility
+            )
+            price = max(0.0, price)
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return PricingResult(
+                contract_id=contract.contract_id,
+                theoretical_price=price,
+                delta=delta,
+                gamma=gamma,
+                theta=theta,
+                vega=vega,
+                rho=rho,
+                implied_volatility=volatility,
+                computation_time_ms=elapsed_ms,
+                model_used="black_scholes",
+            )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            LOGGER.exception("Black-Scholes pricing failed")
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return PricingResult(
+                contract_id=contract.contract_id,
+                theoretical_price=0.0,
+                computation_time_ms=elapsed_ms,
+                model_used="black_scholes",
+                error=str(exc),
+            )
+
+
+@dataclass(slots=True)
 class BinomialModel:
-    def __init__(self,steps:int=200): self.steps=steps
-    def calculate_price(self,c:OptionContract,md:MarketData,vol:float)->PricingResult:
-        t0=time.perf_counter()
+    """Recombining binomial tree pricing model."""
+
+    steps: int = 200
+
+    def calculate_price(
+        self,
+        contract: OptionContract,
+        market_data: MarketData,
+        volatility: float,
+    ) -> PricingResult:
+        start = time.perf_counter()
         try:
-            validate_pricing_parameters(c,md,vol); N=self.steps; dt=c.time_to_expiry/N
-            u=math.exp(vol*math.sqrt(dt)); d=1/u; p=(math.exp((md.risk_free_rate-md.dividend_yield)*dt)-d)/(u-d); p=min(1,max(0,p)); disc=math.exp(-md.risk_free_rate*dt)
-            prices=np.array([md.spot_price*(u**j)*(d**(N-j)) for j in range(N+1)])
-            vals=np.maximum(prices-c.strike_price,0.0) if c.option_type==OptionType.CALL else np.maximum(c.strike_price-prices,0.0)
-            for i in range(N-1,-1,-1):
-                vals=disc*(p*vals[1:]+(1-p)*vals[:-1])
-                prices=prices[:-1]/u
-                if c.exercise_style.name=="AMERICAN":
-                    ex=np.maximum(prices-c.strike_price,0.0) if c.option_type==OptionType.CALL else np.maximum(c.strike_price-prices,0.0)
-                    vals=np.maximum(vals,ex)
-            return PricingResult(c.contract_id,float(vals[0]),model_used=f"binomial_{self.steps}",computation_time_ms=(time.perf_counter()-t0)*1000.0)
-        except Exception as e:
-            log.exception("BIN failed"); return PricingResult(c.contract_id,0.0,error=str(e),computation_time_ms=(time.perf_counter()-t0)*1000.0,model_used=f"binomial_{self.steps}")
+            validate_pricing_parameters(contract, market_data, volatility)
+
+            steps = max(1, self.steps)
+            delta_t = contract.time_to_expiry / steps
+            up = math.exp(volatility * math.sqrt(delta_t))
+            down = 1.0 / up
+
+            growth = math.exp((market_data.risk_free_rate - market_data.dividend_yield) * delta_t)
+            probability = (growth - down) / (up - down)
+            probability = min(1.0, max(0.0, probability))
+            discount = math.exp(-market_data.risk_free_rate * delta_t)
+
+            prices = np.array(
+                [
+                    market_data.spot_price * (up**j) * (down ** (steps - j))
+                    for j in range(steps + 1)
+                ],
+                dtype=float,
+            )
+
+            if contract.option_type is OptionType.CALL:
+                values = np.maximum(prices - contract.strike_price, 0.0)
+            else:
+                values = np.maximum(contract.strike_price - prices, 0.0)
+
+            for index in range(steps - 1, -1, -1):
+                values = discount * (probability * values[1:] + (1.0 - probability) * values[:-1])
+                prices = prices[:-1] / up
+
+                if contract.exercise_style is ExerciseStyle.AMERICAN:
+                    if contract.option_type is OptionType.CALL:
+                        exercise_value = np.maximum(prices - contract.strike_price, 0.0)
+                    else:
+                        exercise_value = np.maximum(contract.strike_price - prices, 0.0)
+                    values = np.maximum(values, exercise_value)
+
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return PricingResult(
+                contract_id=contract.contract_id,
+                theoretical_price=float(values[0]),
+                computation_time_ms=elapsed_ms,
+                model_used=f"binomial_{steps}",
+                implied_volatility=volatility,
+            )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            LOGGER.exception("Binomial pricing failed")
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return PricingResult(
+                contract_id=contract.contract_id,
+                theoretical_price=0.0,
+                computation_time_ms=elapsed_ms,
+                model_used=f"binomial_{self.steps}",
+                error=str(exc),
+            )
+
+
+@dataclass(slots=True)
 class MonteCarloModel:
-    def __init__(self,n:int=20000,antithetic:bool=True): self.n=n; self.antithetic=antithetic
-    def calculate_price(self,c:OptionContract,md:MarketData,vol:float)->PricingResult:
-        t0=time.perf_counter()
+    """Monte Carlo pricer supporting antithetic variates."""
+
+    paths: int = 20_000
+    antithetic: bool = True
+
+    def calculate_price(
+        self,
+        contract: OptionContract,
+        market_data: MarketData,
+        volatility: float,
+    ) -> PricingResult:
+        start = time.perf_counter()
         try:
-            validate_pricing_parameters(c,md,vol); n=self.n//2 if self.antithetic else self.n
-            z=np.random.standard_normal(n); z=np.concatenate([z,-z]) if self.antithetic else z
-            ST=md.spot_price*np.exp((md.risk_free_rate-md.dividend_yield-0.5*vol**2)*c.time_to_expiry + vol*math.sqrt(c.time_to_expiry)*z)
-            pay=np.maximum(ST-c.strike_price,0.0) if c.option_type==OptionType.CALL else np.maximum(c.strike_price-ST,0.0)
-            price=math.exp(-md.risk_free_rate*c.time_to_expiry)*float(np.mean(pay))
-            return PricingResult(c.contract_id,max(0.0,price),model_used=f"monte_carlo_{self.n}",computation_time_ms=(time.perf_counter()-t0)*1000.0)
-        except Exception as e:
-            log.exception("MC failed"); return PricingResult(c.contract_id,0.0,error=str(e),computation_time_ms=(time.perf_counter()-t0)*1000.0,model_used=f"monte_carlo_{self.n}")
+            validate_pricing_parameters(contract, market_data, volatility)
+
+            simulation_paths = max(1, self.paths)
+            if self.antithetic:
+                half_count = max(1, math.ceil(simulation_paths / 2))
+                draws = np.random.standard_normal(half_count).astype(float)
+                draws = np.concatenate([draws, -draws])[:simulation_paths]
+            else:
+                draws = np.random.standard_normal(simulation_paths).astype(float)
+
+            drift = (
+                market_data.risk_free_rate - market_data.dividend_yield - 0.5 * volatility**2
+            ) * contract.time_to_expiry
+            diffusion = volatility * math.sqrt(contract.time_to_expiry) * draws
+            terminal_prices = market_data.spot_price * np.exp(drift + diffusion)
+
+            if contract.option_type is OptionType.CALL:
+                payoff = np.maximum(terminal_prices - contract.strike_price, 0.0)
+            else:
+                payoff = np.maximum(contract.strike_price - terminal_prices, 0.0)
+
+            discounted_payoff = math.exp(
+                -market_data.risk_free_rate * contract.time_to_expiry
+            ) * float(np.mean(payoff))
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return PricingResult(
+                contract_id=contract.contract_id,
+                theoretical_price=max(0.0, discounted_payoff),
+                computation_time_ms=elapsed_ms,
+                model_used=f"monte_carlo_{simulation_paths}",
+                implied_volatility=volatility,
+            )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            LOGGER.exception("Monte Carlo pricing failed")
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return PricingResult(
+                contract_id=contract.contract_id,
+                theoretical_price=0.0,
+                computation_time_ms=elapsed_ms,
+                model_used=f"monte_carlo_{self.paths}",
+                error=str(exc),
+            )

--- a/options-pricing-engine/src/options_engine/core/volatility_surface.py
+++ b/options-pricing-engine/src/options_engine/core/volatility_surface.py
@@ -1,49 +1,150 @@
-import time, logging, numpy as np
+"""Volatility surface utilities."""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
 from dataclasses import dataclass
-from typing import List, Dict, Tuple, Optional
-from scipy.interpolate import griddata, RegularGridInterpolator
-log=logging.getLogger(__name__)
-@dataclass
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator, griddata
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
 class VolatilityPoint:
-    strike: float; maturity: float; volatility: float; timestamp: float; source: str
+    """A single observation on the implied volatility surface."""
+
+    strike: float
+    maturity: float
+    volatility: float
+    timestamp: float
+    source: str
+
+
 class VolatilitySurface:
-    def __init__(self, interpolation_method='linear'):
-        self.points: List[VolatilityPoint]=[]; self.interpolation_method=interpolation_method; self.interpolator=None; self.last_update=0.0; self.surface_cache: Dict[tuple,float]={}; self.cache_ttl=60.0
-    def update_volatility(self,strike:float,maturity:float,vol:float,source='market'):
-        ts=time.time(); 
-        for i,p in enumerate(self.points):
-            if abs(p.strike-strike)<1e-9 and abs(p.maturity-maturity)<1e-9:
-                self.points[i]=VolatilityPoint(strike,maturity,vol,ts,source); break
-        else: self.points.append(VolatilityPoint(strike,maturity,vol,ts,source))
-        self.surface_cache.clear(); self._build(); self.last_update=ts
-    def _build(self):
-        if len(self.points)<4: self.interpolator=None; return
-        strikes=sorted({p.strike for p in self.points}); mats=sorted({p.maturity for p in self.points})
-        grid=np.full((len(strikes),len(mats)), np.nan); mp={(p.strike,p.maturity):p.volatility for p in self.points}
-        for i,s in enumerate(strikes):
-            for j,m in enumerate(mats): grid[i,j]=mp.get((s,m), np.nan)
-        if np.any(np.isnan(grid)):
-            pts=np.array([[p.strike,p.maturity] for p in self.points]); vals=np.array([p.volatility for p in self.points])
-            def scat(X):
-                out=griddata(pts,vals,X,method=self.interpolation_method,fill_value=np.nan)
-                if np.any(np.isnan(out)): out[np.isnan(out)]=griddata(pts,vals,X[np.isnan(out)],method='nearest')
-                return out
-            self.interpolator=scat
+    """Maintains an interpolated implied volatility surface."""
+
+    def __init__(self, interpolation_method: str = "linear", cache_ttl: float = 60.0) -> None:
+        self.interpolation_method = interpolation_method
+        self._points: List[VolatilityPoint] = []
+        self._interpolator: Optional[Callable[[Sequence[Sequence[float]]], np.ndarray]] = None
+        self._cache: Dict[Tuple[float, float], Tuple[float, float]] = {}
+        self._cache_ttl = max(0.0, cache_ttl)
+
+    @property
+    def points(self) -> Tuple[VolatilityPoint, ...]:
+        return tuple(self._points)
+
+    def update_volatility(
+        self,
+        strike: float,
+        maturity: float,
+        volatility: float,
+        *,
+        source: str = "market",
+    ) -> None:
+        if strike <= 0 or maturity <= 0:
+            raise ValueError("strike and maturity must be positive")
+        if not 0.01 <= volatility <= 5.0:
+            raise ValueError("volatility must be within [0.01, 5.0]")
+
+        timestamp = time.time()
+        for index, point in enumerate(self._points):
+            if math.isclose(point.strike, strike, abs_tol=1e-9) and math.isclose(
+                point.maturity, maturity, abs_tol=1e-9
+            ):
+                self._points[index] = VolatilityPoint(
+                    strike, maturity, volatility, timestamp, source
+                )
+                break
         else:
-            self.interpolator=RegularGridInterpolator((strikes,mats),grid,method=self.interpolation_method,bounds_error=False,fill_value=None)
-    def get_volatility(self,strike:float,maturity:float,spot:float)->float:
-        key=(round(strike,4),round(maturity,4)); now=time.time()
-        if key in self.surface_cache and now-self.last_update<self.cache_ttl: return self.surface_cache[key]
-        if self.interpolator is None or len(self.points)<4: vol=0.20
+            self._points.append(VolatilityPoint(strike, maturity, volatility, timestamp, source))
+
+        self._cache.clear()
+        self._interpolator = self._build_interpolator()
+
+    def _build_interpolator(self) -> Optional[Callable[[Sequence[Sequence[float]]], np.ndarray]]:
+        if len(self._points) < 4:
+            return None
+
+        strikes = sorted({point.strike for point in self._points})
+        maturities = sorted({point.maturity for point in self._points})
+        grid = np.full((len(strikes), len(maturities)), np.nan, dtype=float)
+        point_map = {(point.strike, point.maturity): point.volatility for point in self._points}
+
+        for strike_index, strike in enumerate(strikes):
+            for maturity_index, maturity in enumerate(maturities):
+                grid[strike_index, maturity_index] = point_map.get((strike, maturity), np.nan)
+
+        if np.isnan(grid).any():
+            points = np.array(
+                [[point.strike, point.maturity] for point in self._points], dtype=float
+            )
+            values = np.array([point.volatility for point in self._points], dtype=float)
+
+            def interpolator(query: Sequence[Sequence[float]]) -> np.ndarray:
+                query_array = np.asarray(query, dtype=float)
+                result = griddata(
+                    points, values, query_array, method=self.interpolation_method, fill_value=np.nan
+                )
+                if np.isnan(result).any():
+                    nearest = griddata(points, values, query_array, method="nearest")
+                    result = np.where(np.isnan(result), nearest, result)
+                return result
+
+            return interpolator
+
+        return RegularGridInterpolator(
+            (np.array(strikes, dtype=float), np.array(maturities, dtype=float)),
+            grid,
+            method=self.interpolation_method,
+            bounds_error=False,
+            fill_value=None,
+        )
+
+    def get_volatility(self, strike: float, maturity: float, spot: float) -> float:
+        key = (round(strike, 4), round(maturity, 4))
+        now = time.time()
+        cached = self._cache.get(key)
+        if cached and (not self._cache_ttl or now - cached[1] <= self._cache_ttl):
+            return cached[0]
+
+        if self._interpolator is None or len(self._points) < 4:
+            volatility = 0.20
         else:
             try:
-                vol=float(self.interpolator([[strike,maturity]])) if not callable(self.interpolator) else float(self.interpolator(np.array([[strike,maturity]])))
-                if not (0.01<vol<3.0) or np.isnan(vol): vol=self._fallback(strike,maturity)
-            except Exception as e:
-                log.warning("vol interp failed: %s", e); vol=self._fallback(strike,maturity)
-        self.surface_cache[key]=vol; return vol
-    def _fallback(self,strike,maturity):
-        if not self.points: return 0.20
-        d=[(((p.strike-strike)/max(strike,1e-6))**2 + ((p.maturity-maturity)/max(maturity,1e-6))**2, p.volatility) for p in self.points]
-        d.sort(key=lambda x:x[0]); near=d[:min(5,len(d))]; w=[1/(di+1e-6) for di,_ in near]; v=[vi for _,vi in near]; 
-        return float(np.average(v,weights=w))
+                if callable(self._interpolator):
+                    interpolated = self._interpolator([[strike, maturity]])
+                else:
+                    interpolated = self._interpolator([[strike, maturity]])
+                volatility = float(interpolated[0])
+            except Exception as exc:  # pragma: no cover - defensive programming
+                LOGGER.warning("Volatility interpolation failed: %s", exc)
+                volatility = self._fallback(strike, maturity, spot)
+            else:
+                if not 0.01 <= volatility <= 3.0 or math.isnan(volatility):
+                    volatility = self._fallback(strike, maturity, spot)
+
+        self._cache[key] = (volatility, now)
+        return volatility
+
+    def _fallback(self, strike: float, maturity: float, spot: float) -> float:
+        if not self._points:
+            return 0.20
+
+        def distance(point: VolatilityPoint) -> float:
+            strike_scale = max(strike, spot, 1e-6)
+            maturity_scale = max(maturity, 1e-6)
+            return ((point.strike - strike) / strike_scale) ** 2 + (
+                (point.maturity - maturity) / maturity_scale
+            ) ** 2
+
+        sorted_points = sorted(self._points, key=distance)
+        nearest = sorted_points[: min(len(sorted_points), 5)]
+        weights = np.array([1.0 / (distance(point) + 1e-6) for point in nearest], dtype=float)
+        vols = np.array([point.volatility for point in nearest], dtype=float)
+        return float(np.average(vols, weights=weights))

--- a/options-pricing-engine/src/options_engine/tests/unit/test_pricing_engine.py
+++ b/options-pricing-engine/src/options_engine/tests/unit/test_pricing_engine.py
@@ -1,0 +1,44 @@
+"""Tests for the high level pricing engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from options_engine.core.models import MarketData, OptionContract, OptionType
+from options_engine.core.pricing_engine import OptionsEngine
+
+
+def _make_contract(symbol: str, strike: float) -> OptionContract:
+    return OptionContract(
+        symbol=symbol,
+        strike_price=strike,
+        time_to_expiry=1.0,
+        option_type=OptionType.CALL,
+    )
+
+
+def test_portfolio_pricing_preserves_order_and_respects_override() -> None:
+    engine = OptionsEngine(num_threads=2)
+    contracts = [_make_contract("TEST1", 90.0), _make_contract("TEST2", 110.0)]
+    market_data = MarketData(spot_price=100.0, risk_free_rate=0.05, dividend_yield=0.02)
+
+    default_results = engine.price_portfolio(contracts, market_data, model_name="black_scholes")
+    override_results = engine.price_portfolio(
+        contracts,
+        market_data,
+        model_name="black_scholes",
+        override_volatility=0.35,
+    )
+
+    assert [result["contract_id"] for result in override_results] == [
+        contract.contract_id for contract in contracts
+    ]
+    assert override_results[0]["theoretical_price"] != pytest.approx(
+        default_results[0]["theoretical_price"]
+    )
+
+
+def test_calculate_portfolio_greeks_handles_empty_input() -> None:
+    totals = OptionsEngine.calculate_portfolio_greeks([])
+    assert totals["delta"] == 0.0
+    assert totals["position_count"] == 0.0

--- a/options-pricing-engine/src/options_engine/tests/unit/test_pricing_models.py
+++ b/options-pricing-engine/src/options_engine/tests/unit/test_pricing_models.py
@@ -1,8 +1,30 @@
-from options_engine.core.models import OptionContract, MarketData, OptionType
-from options_engine.core.pricing_models import BlackScholesModel
+import math
+import warnings
+
+from options_engine.core.models import MarketData, OptionContract, OptionType
+from options_engine.core.pricing_models import BlackScholesModel, MonteCarloModel
+
+
 def test_bs_runs():
-    m=BlackScholesModel()
-    c=OptionContract(symbol="TEST", strike_price=100.0, time_to_expiry=1.0, option_type=OptionType.CALL)
-    md=MarketData(spot_price=100.0, risk_free_rate=0.05, dividend_yield=0.02)
-    r=m.calculate_price(c, md, 0.2)
+    m = BlackScholesModel()
+    c = OptionContract(
+        symbol="TEST", strike_price=100.0, time_to_expiry=1.0, option_type=OptionType.CALL
+    )
+    md = MarketData(spot_price=100.0, risk_free_rate=0.05, dividend_yield=0.02)
+    r = m.calculate_price(c, md, 0.2)
     assert r.theoretical_price > 0
+
+
+def test_monte_carlo_handles_small_antithetic_path_counts():
+    model = MonteCarloModel(paths=1, antithetic=True)
+    contract = OptionContract(
+        symbol="MC", strike_price=100.0, time_to_expiry=1.0, option_type=OptionType.CALL
+    )
+    market = MarketData(spot_price=100.0, risk_free_rate=0.01)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        result = model.calculate_price(contract, market, 0.2)
+
+    assert not captured
+    assert math.isfinite(result.theoretical_price)

--- a/options-pricing-engine/src/options_engine/utils/validation.py
+++ b/options-pricing-engine/src/options_engine/utils/validation.py
@@ -1,6 +1,31 @@
-from ..core.models import OptionContract, MarketData
-def validate_pricing_parameters(c: OptionContract, md: MarketData, vol: float)->None:
-    if vol<=0 or vol>5.0: raise ValueError("vol out of range")
-    if c.time_to_expiry<=1e-8: raise ValueError("T too small")
-    if md.spot_price<=0: raise ValueError("S>0 required")
-    if c.strike_price<=0: raise ValueError("K>0 required")
+"""Validation helpers for pricing inputs."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ..core.models import MarketData, OptionContract
+
+MAX_VOLATILITY: Final[float] = 5.0
+MIN_VOLATILITY: Final[float] = 1e-6
+MIN_TIME_TO_EXPIRY: Final[float] = 1e-6
+
+
+def validate_pricing_parameters(
+    contract: OptionContract,
+    market_data: MarketData,
+    volatility: float,
+) -> None:
+    """Validate that inputs to a pricing model are well formed."""
+
+    if volatility <= MIN_VOLATILITY or volatility > MAX_VOLATILITY:
+        raise ValueError("volatility is outside the supported range")
+
+    if contract.time_to_expiry <= MIN_TIME_TO_EXPIRY:
+        raise ValueError("time_to_expiry is too small for stable pricing")
+
+    if market_data.spot_price <= 0:
+        raise ValueError("spot_price must be strictly positive")
+
+    if contract.strike_price <= 0:
+        raise ValueError("strike_price must be strictly positive")


### PR DESCRIPTION
## Summary
- tighten the core models, pricing algorithms, and caching so pricing uses validated inputs and stable greeks
- improve the FastAPI surface, security helpers, and response schemas to respect client-provided volatility and log errors cleanly
- add regression tests that ensure portfolio pricing preserves order and handles greek aggregation correctly
- ensure the Monte Carlo pricer handles small antithetic path counts without warnings and allow negative rates through the API schema

## Testing
- pytest
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d3eac632308333845ace61c9645b2b