### PR TITLE
Harden JWT authentication guardrails

### DIFF
--- a/options-pricing-engine/README.md
+++ b/options-pricing-engine/README.md
@@ -25,9 +25,10 @@ operational guardrails.
    export OIDC_JWKS_URL="https://auth.local/.well-known/jwks.json"
    ```
 
-   For local development you may optionally set `OPE_JWT_SECRET` (and rotation values in
-   `OPE_JWT_ADDITIONAL_SECRETS`) to use the built-in HMAC fallback while no OIDC provider is
-   available. The variables are ignored – and forbidden – when `OPE_ENVIRONMENT=production`.
+   For local development you may optionally set `DEV_JWT_SECRET` (and rotation values in
+   `DEV_JWT_ADDITIONAL_SECRETS`) to use the built-in HMAC fallback while no OIDC provider is
+   available. Secrets must decode to at least 32 bytes (base64url or hexadecimal values are
+   accepted). The variables are ignored – and forbidden – when `OPE_ENVIRONMENT=production`.
 
 3. **Launch the API**
 
@@ -60,8 +61,8 @@ defaults in non-production environments but must be explicitly configured in pro
 | `OIDC_JWKS_URL` | **Required in production.** HTTPS endpoint serving the JWKS document. | unset |
 | `RATE_LIMIT_DEFAULT` | Default SlowAPI rate limit applied to authenticated routes. | `60/minute` |
 | `MAX_BODY_BYTES` | Maximum accepted request payload size. | `1_048_576` |
-| `OPE_JWT_SECRET` | Optional symmetric secret for non-production development only. | unset |
-| `OPE_JWT_ADDITIONAL_SECRETS` | Additional development secrets accepted during rotation. | empty |
+| `DEV_JWT_SECRET` | Optional symmetric secret for non-production environments. Must be ≥32 bytes after decoding (base64url or hex). | unset |
+| `DEV_JWT_ADDITIONAL_SECRETS` | Additional development secrets accepted during rotation. Must satisfy the same length/encoding requirements. | empty |
 | `OPE_ALLOWED_HOSTS` | Comma-separated host allow-list for the TrustedHost middleware. **Required in production.** | `localhost,127.0.0.1` |
 | `OPE_ALLOWED_ORIGINS` | CORS allow list. | `http://localhost,http://localhost:3000,http://localhost:8000` |
 | `OPE_CORS_ALLOW_CREDENTIALS` | Whether CORS responses include credentials. | `true` |
@@ -81,9 +82,11 @@ defaults in non-production environments but must be explicitly configured in pro
   `scope` or `scp` claim is parsed as a space-delimited list.
 * JWKS documents are cached for 5 minutes. During key rotation both the previous and current
   keys remain valid automatically.
-* In non-production environments the API can validate tokens signed with `OPE_JWT_SECRET` when an
-  OIDC provider is unavailable. Multiple secrets may be provided to smooth rotations. The fallback
-  is disabled in production.
+* In non-production environments the API can validate tokens signed with `DEV_JWT_SECRET` when an
+  OIDC provider is unavailable. Multiple secrets may be provided (via
+  `DEV_JWT_ADDITIONAL_SECRETS`) to smooth rotations. Development tokens must carry the same
+  `iss`, `aud`, `sub`, `iat`, `nbf` and `exp` claims as production OIDC tokens and are rejected in
+  production deployments.
 * API endpoints attach strict transport security, request IDs and JSON structured logs for every
   call. Headers such as `X-Content-Type-Options` and `Strict-Transport-Security` are enforced by
   middleware.

--- a/options-pricing-engine/SECURITY.md
+++ b/options-pricing-engine/SECURITY.md
@@ -15,10 +15,12 @@ Options Pricing Engine (OPE).
   * Signing keys are cached for five minutes and the previous keyset is kept as
     a grace period so that rotations do not trigger authentication failures.
 * **Development fallback.** When an OIDC provider is unavailable (for example,
-  on an isolated developer laptop), you may provide `OPE_JWT_SECRET` and
-  optional rotation values in `OPE_JWT_ADDITIONAL_SECRETS`. Tokens signed with
-  any of those HMAC secrets are accepted in non-production environments. The
-  legacy secrets are ignored – and rejected – when `OPE_ENVIRONMENT=production`.
+  on an isolated developer laptop), you may provide `DEV_JWT_SECRET` and
+  optional rotation values in `DEV_JWT_ADDITIONAL_SECRETS`. Secrets must decode
+  to ≥32 bytes (base64url or hexadecimal). Development tokens are required to
+  contain the same issuer, audience, subject, issued-at, not-before and expiry
+  claims enforced in OIDC mode. HMAC secrets are ignored – and rejected – when
+  `OPE_ENVIRONMENT=production`.
 
 ## Secret rotation
 
@@ -26,9 +28,10 @@ Options Pricing Engine (OPE).
   automatically refreshes JWKS documents and accepts both the current and
   previously seen keyset during the transition.
 * **Development secrets** can be rotated by deploying with the new value in
-  `OPE_JWT_SECRET` and the previous entries listed in
-  `OPE_JWT_ADDITIONAL_SECRETS`. Once all clients are updated, remove the old
-  values and redeploy.
+  `DEV_JWT_SECRET` and the previous entries listed in
+  `DEV_JWT_ADDITIONAL_SECRETS`. Once all clients are updated, remove the old
+  values and redeploy. Using any development secret in production is treated as
+  a deployment misconfiguration and the application will refuse to start.
 
 ## Transport security
 

--- a/options-pricing-engine/src/options_engine/security/__init__.py
+++ b/options-pricing-engine/src/options_engine/security/__init__.py
@@ -1,5 +1,21 @@
 """Security utilities for the options engine."""
 
-from .oidc import DevelopmentJWTAuthenticator, OIDCAuthenticator, OIDCClaims, JWKSCache
+from .oidc import (
+    CLOCK_SKEW_SECONDS,
+    DevelopmentJWTAuthenticator,
+    OIDCAuthenticator,
+    OIDCClaims,
+    OIDCUnavailableError,
+    JWKSCache,
+    JWKSUnavailableError,
+)
 
-__all__ = ["DevelopmentJWTAuthenticator", "OIDCAuthenticator", "OIDCClaims", "JWKSCache"]
+__all__ = [
+    "CLOCK_SKEW_SECONDS",
+    "DevelopmentJWTAuthenticator",
+    "OIDCAuthenticator",
+    "OIDCClaims",
+    "OIDCUnavailableError",
+    "JWKSCache",
+    "JWKSUnavailableError",
+]

--- a/options-pricing-engine/src/options_engine/security/oidc.py
+++ b/options-pricing-engine/src/options_engine/security/oidc.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Tuple
+
+from jose import JWTError, jwt
 
 try:  # pragma: no cover - httpx optional in offline tests
     import httpx
@@ -13,12 +16,22 @@ except ModuleNotFoundError:  # pragma: no cover
     httpx = None  # type: ignore[assignment]
     import json
     from urllib.request import urlopen
-from jose import JWTError, jwt
 
 CLOCK_SKEW_SECONDS = 60
 _REFRESH_INTERVAL_SECONDS = 300
+_GRACE_REFRESH_SECONDS = 60
+
+logger = logging.getLogger(__name__)
 
 _JWKSFetcher = Callable[[str], Mapping[str, Any]]
+
+
+class JWKSUnavailableError(RuntimeError):
+    """Raised when signing keys cannot be fetched and none are cached."""
+
+
+class OIDCUnavailableError(RuntimeError):
+    """Raised when OIDC verification cannot be performed due to key outages."""
 
 
 def _fetch_jwks(url: str) -> Mapping[str, Any]:
@@ -71,7 +84,19 @@ class JWKSCache:
             self._previous_keys = {}
 
     def _refresh_locked(self) -> None:
-        payload = self._fetcher(self._jwks_url)
+        try:
+            payload = self._fetcher(self._jwks_url)
+        except Exception as exc:  # pragma: no cover - network failures are environment specific
+            if not self._current_keys:
+                raise JWKSUnavailableError("JWKS signing keys are unavailable") from exc
+            logger.warning(
+                "Failed to refresh JWKS keys; continuing with cached keys",
+                exc_info=exc,
+            )
+            grace = min(self._refresh_interval_seconds, _GRACE_REFRESH_SECONDS)
+            self._next_refresh = time.monotonic() + grace
+            return
+
         keys = payload.get("keys", [])
         if not isinstance(keys, Iterable):
             raise RuntimeError("OIDC JWKS payload invalid")
@@ -155,7 +180,10 @@ class OIDCAuthenticator:
             raise JWTError("Token missing 'kid' header")
 
         # Fetch key by kid, then decide algorithm from the KEY (not untrusted header).
-        key = self._jwks_cache.get_key(kid)
+        try:
+            key = self._jwks_cache.get_key(kid)
+        except JWKSUnavailableError as exc:
+            raise OIDCUnavailableError("JWKS signing keys are unavailable") from exc
         key_alg = key.get("alg")
         if not isinstance(key_alg, str) or key_alg not in self._ALLOWED_ALGS:
             # Some JWKS omit 'alg' per key; default by kty conservatively.
@@ -177,6 +205,7 @@ class OIDCAuthenticator:
             "require_exp": True,
             "require_iat": True,
             "require_nbf": True,
+            "leeway": self._clock_skew_seconds,
         }
 
         def _do_decode() -> Mapping[str, Any]:
@@ -187,7 +216,6 @@ class OIDCAuthenticator:
                 audience=self._audience,
                 issuer=self._issuer,
                 options=options,
-                leeway=self._clock_skew_seconds,
             )
 
         try:
@@ -195,7 +223,10 @@ class OIDCAuthenticator:
         except JWTError:
             # Attempt a forced refresh in case the JWKS rotated between requests.
             self._jwks_cache.reset()
-            key = self._jwks_cache.get_key(kid)
+            try:
+                key = self._jwks_cache.get_key(kid)
+            except JWKSUnavailableError as exc:  # pragma: no cover - exercised in integration tests
+                raise OIDCUnavailableError("JWKS signing keys are unavailable") from exc
             key_alg2 = key.get("alg") or key_alg
             claims = jwt.decode(
                 token,
@@ -204,7 +235,6 @@ class OIDCAuthenticator:
                 audience=self._audience,
                 issuer=self._issuer,
                 options=options,
-                leeway=self._clock_skew_seconds,
             )
 
         subject = claims.get("sub")
@@ -218,19 +248,33 @@ class OIDCAuthenticator:
 class DevelopmentJWTAuthenticator:
     """Validate HMAC-signed JWTs for non-production development flows."""
 
-    _ALLOWED_ALGS = ("HS256", "HS384", "HS512")
+    _ALLOWED_ALGS = ("HS256",)
 
     def __init__(
         self,
         *,
-        secrets: Tuple[str, ...],
-        issuer: str | None,
-        audience: str | None,
+        secrets: Tuple[bytes, ...],
+        issuer: str,
+        audience: str,
         clock_skew_seconds: int = CLOCK_SKEW_SECONDS,
     ) -> None:
         if not secrets:
             raise ValueError("at least one development secret must be provided")
-        self._secrets = secrets
+        if not issuer:
+            raise ValueError("issuer must be provided for development tokens")
+        if not audience:
+            raise ValueError("audience must be provided for development tokens")
+
+        normalized: Tuple[bytes, ...] = tuple(
+            secret if isinstance(secret, bytes) else secret.encode("utf-8") for secret in secrets
+        )
+        for index, secret in enumerate(normalized):
+            if len(secret) < 32:
+                raise ValueError(
+                    "development JWT secrets must be at least 32 bytes long"
+                    f" (secret #{index + 1})"
+                )
+        self._secrets = normalized
         self._issuer = issuer
         self._audience = audience
         self._clock_skew_seconds = max(0, clock_skew_seconds)
@@ -251,19 +295,17 @@ class DevelopmentJWTAuthenticator:
             "require_exp": True,
             "require_iat": True,
             "require_nbf": True,
-            "verify_aud": bool(self._audience),
-            "require_aud": bool(self._audience),
+            "verify_aud": True,
+            "require_aud": True,
+            "leeway": self._clock_skew_seconds,
         }
 
         kwargs: Dict[str, Any] = {
             "options": options,
             "algorithms": list(self._ALLOWED_ALGS),
-            "leeway": self._clock_skew_seconds,
+            "audience": self._audience,
+            "issuer": self._issuer,
         }
-        if self._audience:
-            kwargs["audience"] = self._audience
-        if self._issuer:
-            kwargs["issuer"] = self._issuer
 
         last_error: JWTError | None = None
         for secret in self._secrets:
@@ -306,5 +348,7 @@ __all__ = [
     "OIDCAuthenticator",
     "OIDCClaims",
     "JWKSCache",
+    "JWKSUnavailableError",
+    "OIDCUnavailableError",
 ]
 

--- a/options-pricing-engine/src/options_engine/tests/conftest.py
+++ b/options-pricing-engine/src/options_engine/tests/conftest.py
@@ -16,7 +16,7 @@ from options_engine.security import oidc
 
 
 FAKE_KID = "test-key"
-FAKE_SECRET = "test-secret"
+FAKE_SECRET = "dev-secret-value-at-least-32-bytes!!!"
 FAKE_JWKS = {
     "keys": [
         {
@@ -31,7 +31,7 @@ FAKE_JWKS = {
 
 os.environ.setdefault("OIDC_ISSUER", "https://issuer.test")
 os.environ.setdefault("OIDC_AUDIENCE", "options-pricing-engine")
-os.environ.setdefault("OIDC_JWKS_URL", "https://issuer.test/jwks")
+os.environ.setdefault("DEV_JWT_SECRET", FAKE_SECRET)
 os.environ.setdefault("OPE_ALLOWED_HOSTS", "testserver,localhost,127.0.0.1")
 os.environ.setdefault("OPE_ALLOWED_ORIGINS", "http://testserver")
 os.environ.setdefault("OPE_THREADS", "2")
@@ -45,6 +45,8 @@ def _configure_security() -> Iterator[None]:
 
     monkeypatcher = pytest.MonkeyPatch()
     monkeypatcher.setattr(oidc, "_fetch_jwks", lambda _: FAKE_JWKS)
+    monkeypatcher.setenv("DEV_JWT_SECRET", FAKE_SECRET)
+    monkeypatcher.setenv("OIDC_JWKS_URL", "")
     get_settings.cache_clear()
     _get_authenticator.cache_clear()
     yield

--- a/options-pricing-engine/src/options_engine/tests/unit/test_authentication_helpers.py
+++ b/options-pricing-engine/src/options_engine/tests/unit/test_authentication_helpers.py
@@ -1,22 +1,68 @@
 """Unit tests covering authentication helpers."""
 from __future__ import annotations
 
+import base64
 import time
+from collections.abc import Mapping
 from typing import Any
 
 import pytest
-from jose import jwt
+from fastapi import HTTPException, status
+from jose import JWTError, jwt
 
+from options_engine.api import config as api_config
+from options_engine.api import security as api_security
 from options_engine.security import oidc
 
 
 class _FakeJWKSCache:
+    def __init__(self) -> None:
+        self.reset_called = False
+
     def get_key(self, kid: str) -> dict[str, Any]:
         assert kid == "kid-123"
         return {"alg": "RS256"}
 
     def reset(self) -> None:  # pragma: no cover - behaviour not exercised in this test
-        raise AssertionError("reset should not be called")
+        self.reset_called = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    api_config.get_settings.cache_clear()
+    api_security._get_authenticator.cache_clear()
+    yield
+    api_config.get_settings.cache_clear()
+    api_security._get_authenticator.cache_clear()
+
+
+class _RecordingCounter:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def labels(self, **labels: str) -> "_RecordingCounter":
+        self.calls.append(labels)
+        return self
+
+    def inc(self) -> None:
+        if not self.calls:
+            self.calls.append({})
+        current = self.calls[-1]
+        current["count"] = current.get("count", 0) + 1
+
+
+class _StubAuthenticator:
+    def __init__(self, *, result: oidc.OIDCClaims | None = None, error: Exception | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.calls = 0
+
+    def decode(self, token: str) -> oidc.OIDCClaims:
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        assert self._result is not None
+        return self._result
 
 
 def test_oidc_authenticator_passes_clock_skew_to_decoder(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -50,9 +96,12 @@ def test_oidc_authenticator_passes_clock_skew_to_decoder(monkeypatch: pytest.Mon
 
 def test_development_authenticator_accepts_rotated_secret_with_skew() -> None:
     authenticator = oidc.DevelopmentJWTAuthenticator(
-        secrets=("old-secret", "fresh-secret"),
-        issuer=None,
-        audience=None,
+        secrets=(
+            b"old-secret-should-be-at-least-32-bytes!!",
+            b"fresh-secret-should-be-at-least-32-bytes!",
+        ),
+        issuer="https://issuer.test",
+        audience="test-audience",
         clock_skew_seconds=90,
     )
 
@@ -60,12 +109,14 @@ def test_development_authenticator_accepts_rotated_secret_with_skew() -> None:
     token = jwt.encode(
         {
             "sub": "local-user",
+            "iss": "https://issuer.test",
+            "aud": "test-audience",
             "iat": now - 300,
             "nbf": now - 300,
             "exp": now - 30,  # expired but within the configured skew allowance
             "scope": ["pricing:read", "risk:read"],
         },
-        "fresh-secret",
+        b"fresh-secret-should-be-at-least-32-bytes!",
         algorithm="HS256",
     )
 
@@ -73,3 +124,240 @@ def test_development_authenticator_accepts_rotated_secret_with_skew() -> None:
     assert claims.subject == "local-user"
     assert claims.scopes == frozenset({"pricing:read", "risk:read"})
     assert claims.kid == "development"
+
+
+def test_production_rejects_dev_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPE_ENVIRONMENT", "production")
+    monkeypatch.setenv("OPE_ALLOWED_HOSTS", "api.example.com")
+    monkeypatch.setenv("OIDC_ISSUER", "https://issuer.test")
+    monkeypatch.setenv("OIDC_AUDIENCE", "options-pricing-engine")
+    monkeypatch.setenv("OIDC_JWKS_URL", "https://issuer.test/jwks")
+    secret = base64.urlsafe_b64encode(b"x" * 32).decode().rstrip("=")
+    monkeypatch.setenv("DEV_JWT_SECRET", secret)
+
+    with pytest.raises(RuntimeError, match="Development JWT secrets are forbidden"):
+        api_config.get_settings()
+
+
+def test_dev_secret_requires_oidc_claims(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.setenv("OIDC_AUDIENCE", "options-pricing-engine")
+    secret = base64.urlsafe_b64encode(b"y" * 32).decode().rstrip("=")
+    monkeypatch.setenv("DEV_JWT_SECRET", secret)
+
+    with pytest.raises(RuntimeError, match="requires OIDC_ISSUER and OIDC_AUDIENCE"):
+        api_config.get_settings()
+
+
+def test_dev_secret_strength_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OIDC_ISSUER", "https://issuer.test")
+    monkeypatch.setenv("OIDC_AUDIENCE", "options-pricing-engine")
+    monkeypatch.setenv("DEV_JWT_SECRET", "too-short")
+
+    with pytest.raises(RuntimeError, match="at least 32 bytes"):
+        api_config.get_settings()
+
+
+def test_jwks_cache_uses_cached_keys_when_refresh_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    timeline = {"now": 0.0}
+
+    monkeypatch.setattr(oidc.time, "monotonic", lambda: timeline["now"])
+
+    attempts = {"count": 0}
+
+    def _fetcher(_: str) -> Mapping[str, Any]:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return {"keys": [{"kid": "kid-1", "alg": "RS256"}]}
+        raise RuntimeError("jwks down")
+
+    cache = oidc.JWKSCache("https://issuer.test/jwks", refresh_interval_seconds=10, fetcher=_fetcher)
+
+    assert cache.get_key("kid-1")["alg"] == "RS256"
+    timeline["now"] = 20.0
+    assert cache.get_key("kid-1")["alg"] == "RS256"
+    assert attempts["count"] == 2
+
+
+def test_jwks_cache_cold_start_failure() -> None:
+    def _fetcher(_: str) -> Mapping[str, Any]:
+        raise RuntimeError("jwks offline")
+
+    cache = oidc.JWKSCache("https://issuer.test/jwks", fetcher=_fetcher)
+
+    with pytest.raises(oidc.JWKSUnavailableError):
+        cache.get_key("kid-1")
+
+
+def test_oidc_header_alg_spoof_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    authenticator = oidc.OIDCAuthenticator(
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+        jwks_cache=_FakeJWKSCache(),
+    )
+
+    monkeypatch.setattr(
+        oidc.jwt,
+        "get_unverified_header",
+        lambda token: {"kid": "kid-123", "alg": "HS256"},
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_decode(token: str, key: Any, **kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "sub": "user-123",
+            "scope": "",
+            "iss": "https://issuer.test",
+            "aud": "options-pricing-engine",
+            "iat": int(time.time()),
+            "nbf": int(time.time()),
+            "exp": int(time.time()) + 60,
+        }
+
+    monkeypatch.setattr(oidc.jwt, "decode", _fake_decode)
+
+    claims = authenticator.decode("token")
+    assert claims.subject == "user-123"
+    assert captured["algorithms"] == ["RS256"]
+
+
+def test_oidc_mode_rejects_hs_token_even_with_dev_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    authenticator = oidc.OIDCAuthenticator(
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+        jwks_cache=_FakeJWKSCache(),
+    )
+    dev_authenticator = oidc.DevelopmentJWTAuthenticator(
+        secrets=(b"dev-secret-value-at-least-32-bytes!!!",),
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+    )
+    chain = api_security._AuthenticatorChain(primary=authenticator, dev=dev_authenticator)
+
+    monkeypatch.setattr(oidc.jwt, "get_unverified_header", lambda token: {"kid": "kid-123"})
+
+    def _decode(token: str, key: Any, **kwargs: Any) -> dict[str, Any]:
+        if isinstance(key, Mapping):
+            raise JWTError("invalid signature")
+        return {
+            "sub": "dev-user",
+            "scope": "",
+            "iss": "https://issuer.test",
+            "aud": "options-pricing-engine",
+            "iat": int(time.time()) - 10,
+            "nbf": int(time.time()) - 10,
+            "exp": int(time.time()) + 60,
+        }
+
+    monkeypatch.setattr(oidc.jwt, "decode", _decode)
+
+    with pytest.raises(JWTError):
+        chain.decode("token")
+
+
+def test_authenticator_falls_back_to_dev_when_oidc_unavailable() -> None:
+    dev_claims = oidc.OIDCClaims(
+        subject="dev-user",
+        scopes=frozenset(),
+        claims={"sub": "dev-user", "iss": "https://issuer.test", "aud": "options-pricing-engine"},
+        kid="development",
+    )
+    primary = _StubAuthenticator(error=oidc.OIDCUnavailableError("jwks down"))
+    dev = _StubAuthenticator(result=dev_claims)
+    chain = api_security._AuthenticatorChain(primary=primary, dev=dev)
+
+    assert chain.decode("token") is dev_claims
+    assert primary.calls == 1
+    assert dev.calls == 1
+
+
+def test_development_leeway_enforced() -> None:
+    secret = b"dev-secret-value-at-least-32-bytes!!!"
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "sub": "dev-user",
+            "iss": "https://issuer.test",
+            "aud": "options-pricing-engine",
+            "iat": now,
+            "nbf": now + 30,
+            "exp": now + 300,
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+    tolerant = oidc.DevelopmentJWTAuthenticator(
+        secrets=(secret,),
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+        clock_skew_seconds=60,
+    )
+    strict = oidc.DevelopmentJWTAuthenticator(
+        secrets=(secret,),
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+        clock_skew_seconds=0,
+    )
+
+    tolerant.decode(token)
+    with pytest.raises(JWTError):
+        strict.decode(token)
+
+
+def test_oidc_leeway_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = _FakeJWKSCache()
+    authenticator = oidc.OIDCAuthenticator(
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+        jwks_cache=cache,
+        clock_skew_seconds=60,
+    )
+    strict = oidc.OIDCAuthenticator(
+        issuer="https://issuer.test",
+        audience="options-pricing-engine",
+        jwks_cache=cache,
+        clock_skew_seconds=0,
+    )
+
+    monkeypatch.setattr(oidc.jwt, "get_unverified_header", lambda token: {"kid": "kid-123"})
+
+    claims = {
+        "sub": "user-123",
+        "scope": "",
+        "iss": "https://issuer.test",
+        "aud": "options-pricing-engine",
+        "iat": int(time.time()),
+        "nbf": int(time.time()) + 30,
+        "exp": int(time.time()) + 300,
+    }
+
+    def _decode(token: str, key: Any, **kwargs: Any) -> dict[str, Any]:
+        leeway = kwargs["options"]["leeway"]
+        if leeway < 30:
+            raise JWTError("Token used too early")
+        return claims
+
+    monkeypatch.setattr(oidc.jwt, "decode", _decode)
+
+    assert authenticator.decode("token").subject == "user-123"
+    with pytest.raises(JWTError):
+        strict.decode("token")
+
+
+def test_decode_token_returns_503_on_oidc_outage(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _RecordingCounter()
+    monkeypatch.setattr(api_security, "AUTH_FAILURES", recorder)
+    monkeypatch.setattr(
+        api_security,
+        "_get_authenticator",
+        lambda: _StubAuthenticator(error=oidc.OIDCUnavailableError("jwks down")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        api_security._decode_token("token")
+
+    assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert recorder.calls and recorder.calls[-1]["reason"] == "jwks_unavailable"


### PR DESCRIPTION
## Summary
- enforce strong DEV_JWT secret validation, require issuer/audience parity, and block HMAC fallbacks in production
- add an authenticator chain that prefers OIDC, only falls back to dev tokens on JWKS outages, and surfaces temporary outages as 503s with metrics
- harden JWKS caching, restrict accepted algorithms, update docs, and extend tests/fixtures to cover the new authentication behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4da5d48208333bcfa95bd94172d6c