### PR TITLE
Enhance performance benchmark determinism and reporting

### DIFF
--- a/options-pricing-engine/src/options_engine/tests/performance/benchmarks_baseline.json
+++ b/options-pricing-engine/src/options_engine/tests/performance/benchmarks_baseline.json
@@ -1,12 +1,20 @@
 {
   "black_scholes": {
-    "p99_latency_ms": 0.0508
+    "p50_latency_ms": 0.002503,
+    "p95_latency_ms": 0.004211,
+    "p99_latency_ms": 0.004860
   },
   "binomial": {
-    "p99_latency_ms": 9.9
+    "p50_latency_ms": 2.862136,
+    "p95_latency_ms": 3.204430,
+    "p99_latency_ms": 4.498741
   },
   "monte_carlo": {
-    "p99_latency_ms": 2.7341,
-    "median_ci_half_width": 0.1565
+    "p50_latency_ms": 0.514423,
+    "p95_latency_ms": 0.614964,
+    "p99_latency_ms": 0.687510,
+    "median_ci_half_width": 0.154141,
+    "median_ci_bps": 315.460273,
+    "paths_used": 8000
   }
 }


### PR DESCRIPTION
## Summary
- run benchmark warm-ups separately from measurement passes and record percentile metrics per grid cell
- log determinism metadata (seed lineage, VR pipeline, paths, library versions) and surface the slowest benchmark cells
- refresh latency and Monte Carlo CI baselines with new percentile and comparability data

## Testing
- pytest src/options_engine/tests/performance/test_pricing_benchmarks.py


------
https://chatgpt.com/codex/tasks/task_e_68d50c51c6388333ab944cf165658c6d