### PR TITLE
Add minimal core API with replay and deterministic capsules

### DIFF
--- a/options-pricing-engine/src/options_engine/api/capsule.py
+++ b/options-pricing-engine/src/options_engine/api/capsule.py
@@ -1,0 +1,153 @@
+"""In-memory replay capsule management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from threading import Lock
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Tuple
+
+from numpy.random import SeedSequence
+
+from .codec import canonical_dumps, canonical_hash
+
+
+DEFAULT_BUILD_ID = "local-dev"
+IDEMPOTENCY_TTL_SECONDS = 600
+MC_MAX_PATHS = 262_144
+MC_BATCH_AGGREGATE_LIMIT = 1_500_000
+
+
+def derive_seed_lineage(*, seed_prefix: str | None, base_hash: str, index: int = 0) -> str:
+    """Deterministically derive the seed lineage string for a request."""
+
+    if seed_prefix:
+        return f"{seed_prefix.upper()}:{index}"
+    return f"{base_hash}:{index}"
+
+
+def lineage_to_seed_sequence(lineage: str) -> SeedSequence:
+    """Convert the lineage string into a stable :class:`SeedSequence`."""
+
+    digest = sha256(lineage.encode("utf-8")).digest()
+    seed_int = int.from_bytes(digest[:8], "big", signed=False)
+    return SeedSequence(seed_int)
+
+
+def compute_capsule_id(
+    *,
+    request_payload: Mapping[str, Any],
+    model_config: Mapping[str, Any],
+    surface_id: str | None,
+    seed_lineage: str,
+    build_id: str,
+) -> str:
+    """Compute the deterministic capsule identifier."""
+
+    components = (
+        canonical_dumps(request_payload),
+        canonical_dumps(model_config),
+        surface_id or "",
+        seed_lineage,
+        build_id,
+    )
+    sha = sha256()
+    for component in components:
+        sha.update(component.encode("utf-8"))
+    return sha.hexdigest()
+
+
+@dataclass(slots=True)
+class CapsuleRecord:
+    capsule_id: str
+    request_payload: Dict[str, Any]
+    response_payload: Dict[str, Any]
+    seed_lineage: str
+    model_used: Dict[str, Any]
+    build_id: str
+    timestamp: datetime
+
+
+class CapsuleStore:
+    """Simple in-memory capsule store used for replay tests."""
+
+    def __init__(self) -> None:
+        self._records: MutableMapping[str, CapsuleRecord] = {}
+        self._lock = Lock()
+
+    def save(self, record: CapsuleRecord) -> None:
+        with self._lock:
+            self._records[record.capsule_id] = record
+
+    def get(self, capsule_id: str) -> CapsuleRecord | None:
+        with self._lock:
+            record = self._records.get(capsule_id)
+            if record is None:
+                return None
+            return CapsuleRecord(
+                capsule_id=record.capsule_id,
+                request_payload=dict(record.request_payload),
+                response_payload=dict(record.response_payload),
+                seed_lineage=record.seed_lineage,
+                model_used=dict(record.model_used),
+                build_id=record.build_id,
+                timestamp=record.timestamp,
+            )
+
+
+class IdempotencyCache:
+    """In-memory cache keyed by idempotency token and request hash."""
+
+    def __init__(self) -> None:
+        self._entries: MutableMapping[Tuple[str, str], Tuple[float, str]] = {}
+        self._lock = Lock()
+
+    def get(self, key: str, request_hash: str, *, now: float | None = None) -> Optional[str]:
+        moment = now or datetime.now(UTC).timestamp()
+        with self._lock:
+            payload = self._entries.get((key, request_hash))
+            if not payload:
+                return None
+            expires_at, body = payload
+            if expires_at <= moment:
+                self._entries.pop((key, request_hash), None)
+                return None
+            return body
+
+    def put(self, key: str, request_hash: str, body: str, *, now: float | None = None) -> None:
+        moment = now or datetime.now(UTC).timestamp()
+        expires_at = moment + IDEMPOTENCY_TTL_SECONDS
+        with self._lock:
+            self._entries[(key, request_hash)] = (expires_at, body)
+
+
+CAPSULE_STORE = CapsuleStore()
+IDEMPOTENCY_CACHE = IdempotencyCache()
+
+
+def build_capsule_record(
+    *,
+    request_payload: Mapping[str, Any],
+    response_payload: Mapping[str, Any],
+    model_used: Mapping[str, Any],
+    seed_lineage: str,
+    build_id: str,
+) -> CapsuleRecord:
+    capsule_id = compute_capsule_id(
+        request_payload=request_payload,
+        model_config=model_used,
+        surface_id=None,
+        seed_lineage=seed_lineage,
+        build_id=build_id,
+    )
+    return CapsuleRecord(
+        capsule_id=capsule_id,
+        request_payload=dict(request_payload),
+        response_payload=dict(response_payload),
+        seed_lineage=seed_lineage,
+        model_used=dict(model_used),
+        build_id=build_id,
+        timestamp=datetime.now(UTC),
+    )
+

--- a/options-pricing-engine/src/options_engine/api/codec.py
+++ b/options-pricing-engine/src/options_engine/api/codec.py
@@ -1,0 +1,74 @@
+"""Canonical JSON helpers and error translation for the API."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Dict, Iterable, Mapping
+
+from fastapi import HTTPException, Response, status
+
+
+CANONICAL_SEPARATORS = (",", ":")
+
+
+def canonical_dumps(payload: Any) -> str:
+    """Serialize *payload* using a deterministic JSON representation."""
+
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=CANONICAL_SEPARATORS,
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def canonical_hash(payload: Any) -> str:
+    """Return the SHA-256 hash of the canonical JSON encoding of *payload*."""
+
+    return sha256(canonical_dumps(payload).encode("utf-8")).hexdigest()
+
+
+def canonical_response(payload: Mapping[str, Any]) -> Response:
+    """Build a Response object with canonical JSON encoding."""
+
+    body = canonical_dumps(payload)
+    return Response(content=body, media_type="application/json")
+
+
+@dataclass(slots=True)
+class ErrorMapping:
+    status_code: int
+    detail: str
+
+
+VALIDATION_ERROR = ErrorMapping(status.HTTP_400_BAD_REQUEST, "invalid_request")
+UNSUPPORTED_ERROR = ErrorMapping(status.HTTP_422_UNPROCESSABLE_ENTITY, "unsupported_configuration")
+COST_GUARD_ERROR = ErrorMapping(status.HTTP_429_TOO_MANY_REQUESTS, "cost_guard_triggered")
+NOT_FOUND_ERROR = ErrorMapping(status.HTTP_404_NOT_FOUND, "capsule_not_found")
+CONFLICT_ERROR = ErrorMapping(status.HTTP_409_CONFLICT, "build_conflict")
+
+
+def http_error(mapping: ErrorMapping, *, headers: Mapping[str, str] | None = None) -> HTTPException:
+    """Construct a FastAPI HTTPException from an :class:`ErrorMapping`."""
+
+    return HTTPException(status_code=mapping.status_code, detail=mapping.detail, headers=headers)
+
+
+def safe_float(value: float) -> float:
+    """Return a float that is JSON friendly."""
+
+    if math.isnan(value) or math.isinf(value):
+        raise ValueError("non-finite float encountered")
+    return float(value)
+
+
+def monotonic_timestamp() -> float:
+    """Helper used in tests to control time mocking."""
+
+    return time.time()
+

--- a/options-pricing-engine/src/options_engine/api/routes.py
+++ b/options-pricing-engine/src/options_engine/api/routes.py
@@ -1,0 +1,391 @@
+"""FastAPI route registrations for the minimal core API."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import sys
+from importlib import util
+from pathlib import Path as SystemPath
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from fastapi import APIRouter, Body, FastAPI, HTTPException, Path as PathParam, Response
+from pydantic import ValidationError
+
+from ..core.models import ExerciseStyle, MarketData, OptionContract, OptionType
+from ..core.pricing_models import BinomialModel, BlackScholesModel, MonteCarloModel
+from .capsule import (
+    CAPSULE_STORE,
+    DEFAULT_BUILD_ID,
+    IDEMPOTENCY_CACHE,
+    MC_BATCH_AGGREGATE_LIMIT,
+    MC_MAX_PATHS,
+    build_capsule_record,
+    derive_seed_lineage,
+    lineage_to_seed_sequence,
+)
+from .codec import (
+    CONFLICT_ERROR,
+    COST_GUARD_ERROR,
+    NOT_FOUND_ERROR,
+    VALIDATION_ERROR,
+    canonical_dumps,
+    canonical_hash,
+    canonical_response,
+    http_error,
+    safe_float,
+)
+
+
+def _load_schemas_module():
+    module_path = SystemPath(__file__).with_name("schemas.py")
+    spec = util.spec_from_file_location("options_engine.api._minimal_schemas", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise RuntimeError("Failed to load schemas module")
+    module = util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_schemas = _load_schemas_module()
+BatchRequest = _schemas.BatchRequest
+BatchResponse = _schemas.BatchResponse
+BatchResult = _schemas.BatchResult
+ConfidenceInterval = _schemas.ConfidenceInterval
+GreeksOnlyResponse = _schemas.GreeksOnlyResponse
+QuoteRequest = _schemas.QuoteRequest
+QuoteResponse = _schemas.QuoteResponse
+ReplayRequest = _schemas.ReplayRequest
+VersionResponse = _schemas.VersionResponse
+
+
+LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_BUILD_ID = os.getenv("OPTIONS_ENGINE_BUILD_ID", DEFAULT_BUILD_ID)
+BUILD_ID = _DEFAULT_BUILD_ID
+
+
+def _current_build_id() -> str:
+    package = sys.modules.get("options_engine.api.routes")
+    if package is not None:
+        value = package.__dict__.get("BUILD_ID")
+        if isinstance(value, str):
+            return value
+    return _DEFAULT_BUILD_ID
+
+OPTION_TYPE_MAP = {"CALL": OptionType.CALL, "PUT": OptionType.PUT}
+EXERCISE_STYLE_MAP = {"EUROPEAN": ExerciseStyle.EUROPEAN, "AMERICAN": ExerciseStyle.AMERICAN}
+
+BLACK_SCHOLES = BlackScholesModel()
+BINOMIAL_CACHE: Dict[int, BinomialModel] = {}
+
+
+def _get_binomial_model(steps: int) -> BinomialModel:
+    model = BINOMIAL_CACHE.get(steps)
+    if model is None:
+        model = BinomialModel(steps=steps)
+        BINOMIAL_CACHE[steps] = model
+    return model
+
+
+def _build_contract(request: QuoteRequest) -> OptionContract:
+    payload = request.contract
+    option_type = OPTION_TYPE_MAP[payload.option_type]
+    exercise_style = EXERCISE_STYLE_MAP[payload.exercise_style]
+    return OptionContract(
+        symbol=payload.symbol,
+        strike_price=payload.strike_price,
+        time_to_expiry=payload.time_to_expiry,
+        option_type=option_type,
+        exercise_style=exercise_style,
+    )
+
+
+def _build_market(request: QuoteRequest) -> MarketData:
+    market = request.market
+    return MarketData(
+        spot_price=market.spot_price,
+        risk_free_rate=market.risk_free_rate,
+        dividend_yield=market.dividend_yield,
+    )
+
+
+def _greeks_filter(keys: Iterable[Tuple[str, Optional[float]]], request: QuoteRequest) -> Dict[str, float]:
+    greeks_request = request.greeks
+    include_all = greeks_request is None
+    result: Dict[str, float] = {}
+    for name, value in keys:
+        if value is None:
+            continue
+        if include_all or getattr(greeks_request, name, False):
+            result[name] = safe_float(value)
+    return result
+
+
+def _plan_monte_carlo(request: QuoteRequest) -> Tuple[int, bool]:
+    params = request.model.params
+    paths = params.paths if params and params.paths is not None else 20_000
+    antithetic = True if params is None or params.antithetic is None else bool(params.antithetic)
+    max_paths = request.precision.max_paths if request.precision and request.precision.max_paths else MC_MAX_PATHS
+    if max_paths > MC_MAX_PATHS:
+        raise http_error(COST_GUARD_ERROR, headers={"Retry-After": "1"})
+    paths = min(paths, max_paths)
+    if paths > MC_MAX_PATHS:
+        raise http_error(COST_GUARD_ERROR, headers={"Retry-After": "1"})
+    return int(paths), antithetic
+
+
+def _confidence_interval(price: float, standard_error: Optional[float], paths_used: int, *, vr_pipeline: str) -> ConfidenceInterval | None:
+    if standard_error is None:
+        return None
+    half_width_abs = 1.96 * standard_error
+    denominator = max(abs(price), 1e-6)
+    half_width_bps = 10_000.0 * half_width_abs / denominator
+    return ConfidenceInterval(
+        half_width_abs=safe_float(half_width_abs),
+        half_width_bps=safe_float(half_width_bps),
+        paths_used=int(paths_used),
+        vr_pipeline=vr_pipeline,
+    )
+
+
+def _log_request(
+    *,
+    start_time: float,
+    request: QuoteRequest,
+    model_family: str,
+    capsule_id: str,
+    ci: ConfidenceInterval | None,
+) -> None:
+    latency_ms = (time.perf_counter() - start_time) * 1000.0
+    spot = request.market.spot_price
+    strike = request.contract.strike_price
+    tau = request.contract.time_to_expiry
+    moneyness = spot / strike if strike else float("inf")
+    if moneyness < 0.8:
+        money_bucket = "deep_otm"
+    elif moneyness > 1.2:
+        money_bucket = "deep_itm"
+    else:
+        money_bucket = "near_atm"
+    if tau < 0.25:
+        tau_bucket = "short"
+    elif tau < 1.0:
+        tau_bucket = "medium"
+    else:
+        tau_bucket = "long"
+    ci_bps = ci.half_width_bps if ci else 0.0
+    paths_used = ci.paths_used if ci else 0
+    vr_pipeline = ci.vr_pipeline if ci else "none"
+    message = (
+        f"latency_ms={latency_ms:.2f} model_family={model_family} "
+        f"moneyness_bucket={money_bucket} tau_bucket={tau_bucket} "
+        f"vr_pipeline={vr_pipeline} paths_used={paths_used} ci_bps={ci_bps:.4f} "
+        f"capsule_id={capsule_id}"
+    )
+    print(message)
+
+
+def _execute_quote(
+    request: QuoteRequest,
+    *,
+    index: int,
+    idempotency_key: Optional[str] = None,
+) -> Tuple[Dict[str, Any], str]:
+    request_payload = request.model_dump(exclude_none=True)
+    request_payload.pop("idempotency_key", None)
+    request_hash = canonical_hash(request_payload)
+
+    if idempotency_key:
+        cached = IDEMPOTENCY_CACHE.get(idempotency_key, request_hash)
+        if cached is not None:
+            return json_response_from_body(cached)
+
+    start = time.perf_counter()
+    try:
+        contract = _build_contract(request)
+        market = _build_market(request)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - guarded in tests
+        raise http_error(VALIDATION_ERROR) from exc
+
+    family = request.model.family
+    params = request.model.params
+    model_used: Dict[str, Any] = {"family": family, "params": {}}
+    seed_prefix = params.seed_prefix if params else None
+    seed_lineage = derive_seed_lineage(seed_prefix=seed_prefix, base_hash=request_hash, index=index)
+
+    if family == "black_scholes":
+        result = BLACK_SCHOLES.calculate_price(contract, market, request.volatility)
+        ci = None
+    elif family == "binomial":
+        steps = params.steps if params and params.steps is not None else 200
+        model_used["params"]["steps"] = steps
+        model = _get_binomial_model(int(steps))
+        result = model.calculate_price(contract, market, request.volatility)
+        ci = None
+    elif family == "monte_carlo":
+        paths, antithetic = _plan_monte_carlo(request)
+        model_used["params"].update({"paths": paths, "antithetic": antithetic})
+        seed_sequence = lineage_to_seed_sequence(seed_lineage)
+        model = MonteCarloModel(paths=paths, antithetic=antithetic, seed_sequence=seed_sequence)
+        result = model.calculate_price(
+            contract,
+            market,
+            request.volatility,
+            seed_sequence=seed_sequence,
+        )
+        ci = _confidence_interval(
+            result.theoretical_price,
+            result.standard_error,
+            paths_used=paths,
+            vr_pipeline="antithetic" if antithetic else "baseline",
+        )
+    else:  # pragma: no cover - defensive programming
+        raise http_error(VALIDATION_ERROR)
+
+    greeks = _greeks_filter(
+        (
+            ("delta", result.delta),
+            ("gamma", result.gamma),
+            ("vega", result.vega),
+            ("theta", result.theta),
+            ("rho", result.rho),
+        ),
+        request,
+    )
+
+    response_payload: Dict[str, Any] = {
+        "theoretical_price": safe_float(result.theoretical_price),
+        "model_used": model_used,
+        "capsule_id": "",
+    }
+    if greeks:
+        response_payload["greeks"] = greeks
+    if ci is not None:
+        response_payload["ci"] = ci.model_dump()
+    response_payload["seed_lineage"] = seed_lineage
+
+    capsule_record = build_capsule_record(
+        request_payload=request_payload,
+        response_payload=response_payload,
+        model_used=model_used,
+        seed_lineage=seed_lineage,
+        build_id=_current_build_id(),
+    )
+    response_payload["capsule_id"] = capsule_record.capsule_id
+    CAPSULE_STORE.save(capsule_record)
+
+    _log_request(
+        start_time=start,
+        request=request,
+        model_family=family,
+        capsule_id=capsule_record.capsule_id,
+        ci=ci,
+    )
+
+    body = canonical_dumps(response_payload)
+    if idempotency_key:
+        IDEMPOTENCY_CACHE.put(idempotency_key, request_hash, body)
+
+    return response_payload, body
+
+
+def json_response_from_body(body: str) -> Tuple[Dict[str, Any], str]:
+    payload = QuoteResponse.model_validate_json(body).model_dump()
+    return payload, body
+
+
+def register_routes(app: FastAPI) -> None:
+    router = APIRouter()
+
+    @router.post("/quote")
+    def quote_endpoint(request: QuoteRequest) -> Any:
+        _, body = _execute_quote(request, index=0, idempotency_key=request.idempotency_key)
+        return Response(content=body, media_type="application/json")
+
+    @router.post("/batch")
+    def batch_endpoint(request: BatchRequest) -> Any:
+        if len(request.items) > 100:
+            raise http_error(COST_GUARD_ERROR, headers={"Retry-After": "1"})
+
+        greeks_default = request.greeks_default.model_dump() if request.greeks_default else None
+        parsed_items: List[QuoteRequest | None] = []
+
+        for raw_item in request.items:
+            payload = dict(raw_item)
+            if greeks_default and "greeks" not in payload:
+                payload["greeks"] = greeks_default
+            try:
+                item = QuoteRequest.model_validate(payload)
+            except ValidationError:
+                parsed_items.append(None)
+            else:
+                parsed_items.append(item)
+
+        aggregate_paths = 0
+        for item in parsed_items:
+            if item is not None and item.model.family == "monte_carlo":
+                paths, _ = _plan_monte_carlo(item)
+                aggregate_paths += paths
+        if aggregate_paths > MC_BATCH_AGGREGATE_LIMIT:
+            raise http_error(COST_GUARD_ERROR, headers={"Retry-After": "1"})
+
+        results: List[BatchResult] = []
+        capsule_ids: List[str] = []
+        for index, item in enumerate(parsed_items):
+            if item is None:
+                results.append(BatchResult(index=index, ok=False, error=VALIDATION_ERROR.detail))
+                continue
+            try:
+                payload, _ = _execute_quote(item, index=index)
+                results.append(BatchResult(index=index, ok=True, value=QuoteResponse(**payload)))
+                capsule_ids.append(payload["capsule_id"])
+            except HTTPException as exc:
+                results.append(BatchResult(index=index, ok=False, error=str(exc.detail)))
+
+        response_payload = BatchResponse(results=results, capsule_ids=capsule_ids).model_dump()
+        return canonical_response(response_payload)
+
+    @router.post("/greeks")
+    def greeks_endpoint(request: QuoteRequest) -> Any:
+        request.greeks = request.greeks or None
+        payload, body = _execute_quote(request, index=0)
+        greeks = payload.get("greeks") or {}
+        response = GreeksOnlyResponse(
+            greeks=greeks,
+            capsule_id=payload["capsule_id"],
+            model_used=payload["model_used"],
+        ).model_dump()
+        return canonical_response(response)
+
+    @router.get("/version")
+    def version_endpoint() -> Any:
+        import numpy
+        import scipy
+
+        payload = VersionResponse(
+            build_id=_current_build_id(),
+            library_versions={"numpy": numpy.__version__, "scipy": scipy.__version__},
+            flags={"qmc": False, "stratified": False, "cv": True},
+        ).model_dump()
+        return canonical_response(payload)
+
+    @router.post("/replay/{capsule_id}")
+    def replay_endpoint(
+        capsule_id: str = PathParam(...), request: ReplayRequest = Body(default=ReplayRequest())
+    ) -> Any:
+        record = CAPSULE_STORE.get(capsule_id)
+        if record is None:
+            raise http_error(NOT_FOUND_ERROR)
+        strict = request.strict_build if request else False
+        if strict and record.build_id != _current_build_id():
+            raise http_error(CONFLICT_ERROR)
+        payload = dict(record.response_payload)
+        payload["capsule_id"] = record.capsule_id
+        payload["replayed"] = True
+        return canonical_response(payload)
+
+    app.include_router(router)
+

--- a/options-pricing-engine/src/options_engine/api/routes/__init__.py
+++ b/options-pricing-engine/src/options_engine/api/routes/__init__.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+from typing import Any
+
+
+_MODULE_NAME = "options_engine.api._minimal_routes"
+_module = sys.modules.get(_MODULE_NAME)
+if _module is None:
+    module_path = Path(__file__).resolve().parent.parent / "routes.py"
+    spec = util.spec_from_file_location(_MODULE_NAME, module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise RuntimeError("Unable to load minimal routes module")
+    _module = util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = _module
+    spec.loader.exec_module(_module)
+
+BUILD_ID = _module.__dict__.get("_DEFAULT_BUILD_ID", "")
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"register_routes", "BUILD_ID"}:
+        return getattr(_module, name)
+    raise AttributeError(name)
+
+
+def __setattr__(name: str, value: Any) -> None:  # pragma: no cover - setters only used in tests
+    if name == "BUILD_ID":
+        setattr(_module, name, value)
+    else:
+        raise AttributeError(name)
+
+
+__all__ = ["register_routes", "BUILD_ID"]

--- a/options-pricing-engine/src/options_engine/api/schemas.py
+++ b/options-pricing-engine/src/options_engine/api/schemas.py
@@ -1,0 +1,153 @@
+"""Pydantic models representing the external API surface."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ContractPayload(BaseModel):
+    symbol: str
+    strike_price: float = Field(gt=0)
+    time_to_expiry: float = Field(alias="time_to_expiry", ge=1e-6)
+    option_type: str
+    exercise_style: str = "EUROPEAN"
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("option_type", mode="before")
+    @classmethod
+    def _normalise_option_type(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("option_type must be a string")
+        normalised = value.strip().upper()
+        if normalised not in {"CALL", "PUT"}:
+            raise ValueError("unsupported option_type")
+        return normalised
+
+    @field_validator("exercise_style", mode="before")
+    @classmethod
+    def _normalise_exercise_style(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("exercise_style must be a string")
+        normalised = value.strip().upper()
+        if normalised not in {"EUROPEAN", "AMERICAN"}:
+            raise ValueError("unsupported exercise_style")
+        return normalised
+
+
+class MarketPayload(BaseModel):
+    spot_price: float = Field(gt=0)
+    risk_free_rate: float
+    dividend_yield: float = 0.0
+
+    @field_validator("risk_free_rate", "dividend_yield", mode="before")
+    @classmethod
+    def _clamp_rates(cls, value: float, info) -> float:
+        if value is None:
+            raise TypeError("rate must be provided")
+        rate = float(value)
+        if info.field_name == "risk_free_rate" and not (-0.5 <= rate <= 1.0):
+            raise ValueError("risk_free_rate out of bounds")
+        if info.field_name == "dividend_yield" and not (-0.5 <= rate <= 1.0):
+            raise ValueError("dividend_yield out of bounds")
+        return rate
+
+
+class ModelPrecision(BaseModel):
+    target_ci_bps: Optional[float] = Field(default=None, gt=0)
+    max_paths: Optional[int] = Field(default=None, ge=1_000, le=1_000_000)
+
+
+class ModelParams(BaseModel):
+    paths: Optional[int] = Field(default=None, ge=1_000, le=1_000_000)
+    steps: Optional[int] = Field(default=None, ge=10, le=10_000)
+    antithetic: Optional[bool] = None
+    seed_prefix: Optional[str] = None
+
+
+class ModelSelector(BaseModel):
+    family: str
+    params: ModelParams | None = None
+
+    @field_validator("family", mode="before")
+    @classmethod
+    def _normalise_family(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("model family must be a string")
+        normalised = value.strip().lower()
+        if normalised not in {"black_scholes", "binomial", "monte_carlo"}:
+            raise ValueError("unsupported model family")
+        return normalised
+
+
+class GreeksRequest(BaseModel):
+    delta: bool = False
+    gamma: bool = False
+    vega: bool = False
+    theta: bool = False
+    rho: bool = False
+
+
+class QuoteRequest(BaseModel):
+    contract: ContractPayload
+    market: MarketPayload
+    volatility: float = Field(gt=1e-5, le=5.0)
+    model: ModelSelector = Field(default_factory=lambda: ModelSelector(family="black_scholes"))
+    greeks: Optional[GreeksRequest] = None
+    precision: Optional[ModelPrecision] = None
+    idempotency_key: Optional[str] = None
+
+
+class ConfidenceInterval(BaseModel):
+    half_width_abs: float
+    half_width_bps: float
+    paths_used: int
+    vr_pipeline: str
+
+
+class QuoteResponse(BaseModel):
+    theoretical_price: float
+    greeks: Optional[Dict[str, float]] = None
+    ci: Optional[ConfidenceInterval] = None
+    capsule_id: str
+    model_used: Dict[str, Any]
+    surface_id: Optional[str] = None
+    seed_lineage: Optional[str] = None
+
+
+class BatchRequest(BaseModel):
+    items: List[Dict[str, Any]]
+    greeks_default: Optional[GreeksRequest] = None
+
+
+class BatchResult(BaseModel):
+    index: int
+    ok: bool
+    value: Optional[QuoteResponse] = None
+    error: Optional[str] = None
+
+
+class BatchResponse(BaseModel):
+    results: List[BatchResult]
+    capsule_ids: List[str]
+
+
+class GreeksOnlyResponse(BaseModel):
+    greeks: Dict[str, float]
+    capsule_id: str
+    model_used: Dict[str, Any]
+
+
+class VersionResponse(BaseModel):
+    build_id: str
+    sbom_hash: Optional[str] = None
+    library_versions: Dict[str, str]
+    flags: Dict[str, bool]
+    baseline_tag: Optional[str] = None
+
+
+class ReplayRequest(BaseModel):
+    strict_build: bool = False
+

--- a/options-pricing-engine/src/options_engine/api/server.py
+++ b/options-pricing-engine/src/options_engine/api/server.py
@@ -1,0 +1,34 @@
+"""Minimal FastAPI application exposing the core pricing API."""
+
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+
+from fastapi import FastAPI
+
+
+def _load_routes_module():
+    module_path = Path(__file__).with_name("routes.py")
+    spec = util.spec_from_file_location("options_engine.api._minimal_routes", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load routes module")
+    module = util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_app() -> FastAPI:
+    """Instantiate and configure the FastAPI application."""
+
+    routes_module = _load_routes_module()
+    register_routes = getattr(routes_module, "register_routes")
+    app = FastAPI(title="Options Pricing Engine", version="minimal-core")
+    register_routes(app)
+    return app
+
+
+app = create_app()
+

--- a/options-pricing-engine/src/options_engine/tests/api/test_api_core.py
+++ b/options-pricing-engine/src/options_engine/tests/api/test_api_core.py
@@ -1,0 +1,145 @@
+"""Integration tests covering the minimal API surface."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from options_engine.api.server import create_app
+from options_engine.core.pricing_models import BlackScholesModel
+from options_engine.core.models import MarketData, OptionContract, OptionType
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def _quote_payload(model: Dict[str, object] | None = None) -> Dict[str, object]:
+    payload: Dict[str, object] = {
+        "contract": {
+            "symbol": "AAPL",
+            "strike_price": 150.0,
+            "time_to_expiry": 0.5,
+            "option_type": "call",
+            "exercise_style": "european",
+        },
+        "market": {
+            "spot_price": 147.0,
+            "risk_free_rate": 0.01,
+            "dividend_yield": 0.0,
+        },
+        "volatility": 0.25,
+        "model": model or {"family": "black_scholes"},
+    }
+    return payload
+
+
+def test_quote_black_scholes_returns_price_and_greeks(client: TestClient) -> None:
+    response = client.post("/quote", json=_quote_payload())
+    assert response.status_code == 200
+    data = response.json()
+
+    contract = OptionContract(
+        symbol="AAPL",
+        strike_price=150.0,
+        time_to_expiry=0.5,
+        option_type=OptionType.CALL,
+    )
+    market = MarketData(spot_price=147.0, risk_free_rate=0.01, dividend_yield=0.0)
+    expected = BlackScholesModel().calculate_price(contract, market, 0.25)
+
+    assert pytest.approx(expected.theoretical_price, rel=1e-10) == data["theoretical_price"]
+    assert "capsule_id" in data
+    assert "ci" not in data
+    greeks = data.get("greeks")
+    assert greeks is not None
+    for key in ("delta", "gamma", "theta", "vega", "rho"):
+        assert key in greeks
+
+
+def test_quote_monte_carlo_returns_confidence_interval(client: TestClient) -> None:
+    payload = _quote_payload(model={"family": "monte_carlo", "params": {"paths": 8192}})
+    response = client.post("/quote", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "ci" in data
+    ci = data["ci"]
+    assert ci["paths_used"] == 8192
+    assert ci["vr_pipeline"] in {"antithetic", "baseline"}
+    assert ci["half_width_abs"] > 0.0
+    assert ci["half_width_bps"] > 0.0
+
+
+def test_batch_endpoint_handles_partial_failures(client: TestClient) -> None:
+    payload = {
+        "items": [
+            _quote_payload(),
+            {
+                **_quote_payload(),
+                "market": {"spot_price": -1.0, "risk_free_rate": 0.01, "dividend_yield": 0.0},
+            },
+        ]
+    }
+    response = client.post("/batch", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data["results"]) == 2
+    first, second = data["results"]
+    assert first["ok"] is True
+    assert second["ok"] is False
+    assert second["error"] == "invalid_request"
+    assert len(data["capsule_ids"]) == 1
+
+
+def test_batch_enforces_item_limit(client: TestClient) -> None:
+    payload = {"items": [_quote_payload() for _ in range(101)]}
+    response = client.post("/batch", json=payload)
+    assert response.status_code == 429
+    assert response.headers.get("Retry-After") == "1"
+
+
+def test_greeks_endpoint_matches_analytic(client: TestClient) -> None:
+    payload = _quote_payload()
+    response = client.post("/greeks", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    contract = OptionContract(
+        symbol="AAPL",
+        strike_price=150.0,
+        time_to_expiry=0.5,
+        option_type=OptionType.CALL,
+    )
+    market = MarketData(spot_price=147.0, risk_free_rate=0.01, dividend_yield=0.0)
+    expected = BlackScholesModel().calculate_price(contract, market, 0.25)
+
+    for key, value in data["greeks"].items():
+        expected_value = getattr(expected, key)
+        assert expected_value is not None
+        assert pytest.approx(expected_value, rel=1e-8) == value
+
+
+def test_version_endpoint_contains_library_versions(client: TestClient) -> None:
+    response = client.get("/version")
+    assert response.status_code == 200
+    data = response.json()
+    assert "build_id" in data
+    assert "numpy" in data["library_versions"]
+
+
+def test_idempotency_returns_identical_body(client: TestClient) -> None:
+    payload = _quote_payload()
+    payload["idempotency_key"] = "test-key"
+
+    first = client.post("/quote", json=payload)
+    second = client.post("/quote", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.text == second.text
+

--- a/options-pricing-engine/src/options_engine/tests/api/test_api_replay.py
+++ b/options-pricing-engine/src/options_engine/tests/api/test_api_replay.py
@@ -1,0 +1,59 @@
+"""Replay endpoint behaviour tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from options_engine.api import routes
+from options_engine.api.server import create_app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def _monte_carlo_payload() -> dict[str, object]:
+    return {
+        "contract": {
+            "symbol": "MSFT",
+            "strike_price": 300.0,
+            "time_to_expiry": 0.75,
+            "option_type": "call",
+            "exercise_style": "european",
+        },
+        "market": {
+            "spot_price": 305.0,
+            "risk_free_rate": 0.02,
+            "dividend_yield": 0.0,
+        },
+        "volatility": 0.3,
+        "model": {"family": "monte_carlo", "params": {"paths": 4096}},
+    }
+
+
+def test_replay_returns_identical_results(client: TestClient) -> None:
+    quote = client.post("/quote", json=_monte_carlo_payload())
+    assert quote.status_code == 200
+    quote_body = quote.json()
+
+    capsule_id = quote_body["capsule_id"]
+    replay = client.post(f"/replay/{capsule_id}", json={"strict_build": True})
+    assert replay.status_code == 200
+    replay_body = replay.json()
+
+    assert replay_body["capsule_id"] == capsule_id
+    assert replay_body["replayed"] is True
+    assert pytest.approx(quote_body["theoretical_price"], rel=0, abs=1e-12) == replay_body["theoretical_price"]
+
+
+def test_replay_strict_build_conflict(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    quote = client.post("/quote", json=_monte_carlo_payload())
+    capsule_id = quote.json()["capsule_id"]
+
+    monkeypatch.setattr(routes, "BUILD_ID", "different-build")
+
+    replay = client.post(f"/replay/{capsule_id}", json={"strict_build": True})
+    assert replay.status_code == 409
+


### PR DESCRIPTION
## Summary
- add canonical JSON helpers and capsule storage utilities for deterministic ids and idempotent responses
- expose a minimal FastAPI server with quote, greeks, batch, version, and replay routes backed by core pricing models
- define request/response schemas and cover the new surface with core and replay API tests

## Testing
- `pytest src/options_engine/tests/api -q`


------
https://chatgpt.com/codex/tasks/task_e_68d556c79ef88333b16cea5db5fc945c