### PR TITLE
Accept Monte Carlo variance reduction flags

### DIFF
--- a/options-pricing-engine/src/options_engine/api/schemas.py
+++ b/options-pricing-engine/src/options_engine/api/schemas.py
@@ -65,6 +65,8 @@ class ModelParams(BaseModel):
     steps: Optional[int] = Field(default=None, ge=10, le=10_000)
     antithetic: Optional[bool] = None
     seed_prefix: Optional[str] = None
+    use_qmc: Optional[bool] = None
+    use_cv: Optional[bool] = None
 
 
 class ModelSelector(BaseModel):


### PR DESCRIPTION
## Summary
- accept the new Monte Carlo variance-reduction flags in the request schema
- surface the derived Monte Carlo plan in responses, including VR pipeline labelling
- allow toggling control variates in the Monte Carlo pricer and cover the new API behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d55fe2c19c8333b941ed0b485acb73