### PR TITLE
Implement deterministic volatility surface calibration pipeline

### DIFF
--- a/options-pricing-engine/src/options_engine/api/routes.py
+++ b/options-pricing-engine/src/options_engine/api/routes.py
@@ -304,6 +304,8 @@ def _execute_quote(
         "model_used": model_used,
         "capsule_id": "",
     }
+    if request.surface is not None:
+        response_payload["surface_id"] = request.surface.resolved_id()
     if greeks:
         response_payload["greeks"] = greeks
     if ci is not None:

--- a/options-pricing-engine/src/options_engine/calib/__init__.py
+++ b/options-pricing-engine/src/options_engine/calib/__init__.py
@@ -1,0 +1,23 @@
+"""Volatility surface calibration pipeline."""
+
+from .boards import BoardCleaner, CleanBoard
+from .validators import NoArbitrageValidator, ValidationReport
+from .sabr import SABRCalibrator, SABRTenorResult, SABRConfig
+from .heston_qe import HestonQECalibrator, HestonConfig, HestonTenorResult
+from .select import SurfaceBuilder, SurfaceBuildResult, TenorSelection
+
+__all__ = [
+    "BoardCleaner",
+    "CleanBoard",
+    "NoArbitrageValidator",
+    "ValidationReport",
+    "SABRCalibrator",
+    "SABRTenorResult",
+    "SABRConfig",
+    "HestonQECalibrator",
+    "HestonConfig",
+    "HestonTenorResult",
+    "SurfaceBuilder",
+    "SurfaceBuildResult",
+    "TenorSelection",
+]

--- a/options-pricing-engine/src/options_engine/calib/boards.py
+++ b/options-pricing-engine/src/options_engine/calib/boards.py
@@ -1,0 +1,258 @@
+"""Quote board ingestion and cleaning utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(slots=True)
+class CleanBoard:
+    """Container holding the cleaned quotes and QC metadata."""
+
+    quotes: pd.DataFrame
+    qc: Dict[str, Any]
+
+    def to_records(self) -> List[Dict[str, Any]]:
+        """Return the cleaned quotes as JSON serialisable records."""
+
+        if self.quotes.empty:
+            return []
+        ordered = self.quotes.sort_values(["tenor", "strike", "option_type"]).reset_index(drop=True)
+        records = ordered.to_dict("records")
+        for record in records:
+            for key, value in list(record.items()):
+                if isinstance(value, (np.floating, np.integer)):
+                    record[key] = float(value)
+                elif isinstance(value, (datetime, np.datetime64, pd.Timestamp)):
+                    timestamp = pd.to_datetime(value, utc=True, errors="coerce")
+                    if pd.isna(timestamp):
+                        record[key] = None
+                    else:
+                        record[key] = timestamp.isoformat()
+        return records
+
+
+@dataclass(slots=True)
+class BoardCleanerConfig:
+    """Configuration for :class:`BoardCleaner`."""
+
+    max_age_seconds: float = 5 * 60.0
+    mad_threshold: float = 4.0
+    tau_min_days: float = 1e-4
+    sigma_min: float = 1e-4
+    log_money_bounds: Tuple[float, float] = (-4.0, 4.0)
+    log_money_bins: Sequence[float] = tuple(np.linspace(-4.0, 4.0, 17))
+
+
+class BoardCleaner:
+    """Ingest raw quotes and apply deterministic cleaning rules."""
+
+    REQUIRED_COLUMNS = {"tenor", "strike", "mid_iv", "forward"}
+
+    def __init__(self, config: Optional[BoardCleanerConfig] = None) -> None:
+        self._config = config or BoardCleanerConfig()
+
+    def ingest(
+        self,
+        quotes: Iterable[Mapping[str, Any]],
+        *,
+        now: Optional[datetime] = None,
+        seed: int = 0,
+    ) -> CleanBoard:
+        """Clean the provided quotes and return a :class:`CleanBoard`.
+
+        Parameters
+        ----------
+        quotes:
+            Iterable of mappings representing raw quotes. Each mapping must include
+            at least ``tenor`` (in years), ``strike``, ``mid_iv`` (Black implied vol),
+            and ``forward``. Optional columns include ``option_type`` (``CALL`` or
+            ``PUT``), ``bid_iv``, ``ask_iv`` and ``timestamp``. Missing option types
+            default to calls. Any additional fields are preserved during cleaning.
+        now:
+            Timestamp used to evaluate quote staleness. Defaults to ``datetime.now(UTC)``.
+        seed:
+            RNG seed used when breaking ties deterministically. The cleaning pipeline
+            itself is deterministic but we honour the seed to make any potential
+            floating point ties reproducible across platforms.
+        """
+
+        df = pd.DataFrame(list(quotes))
+        if df.empty:
+            return CleanBoard(df, self._empty_report())
+
+        missing = self.REQUIRED_COLUMNS - set(df.columns)
+        if missing:
+            missing_str = ", ".join(sorted(missing))
+            raise KeyError(f"missing required columns: {missing_str}")
+
+        df = df.replace([np.nan, np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["tenor", "strike", "mid_iv", "forward"])
+
+        df["tenor"] = pd.to_numeric(df["tenor"], errors="coerce")
+        df["strike"] = pd.to_numeric(df["strike"], errors="coerce")
+        df["mid_iv"] = pd.to_numeric(df["mid_iv"], errors="coerce")
+        df["forward"] = pd.to_numeric(df["forward"], errors="coerce")
+
+        df = df.dropna(subset=["tenor", "strike", "mid_iv", "forward"])
+
+        cfg = self._config
+        df = df[df["tenor"] >= max(cfg.tau_min_days / 365.0, 0.0)]
+        df = df[df["mid_iv"] >= cfg.sigma_min]
+
+        if df.empty:
+            return CleanBoard(df, self._empty_report())
+
+        total = len(df)
+        removals: List[Dict[str, Any]] = []
+
+        if "bid_iv" in df.columns and "ask_iv" in df.columns:
+            df["bid_iv"] = pd.to_numeric(df["bid_iv"], errors="coerce")
+            df["ask_iv"] = pd.to_numeric(df["ask_iv"], errors="coerce")
+            crossed = df["bid_iv"] > df["ask_iv"]
+            if crossed.any():
+                removals.extend(
+                    {
+                        "index": int(idx),
+                        "tenor": float(row.tenor),
+                        "strike": float(row.strike),
+                        "reason": "crossed",
+                    }
+                    for idx, row in df.loc[crossed].iterrows()
+                )
+            df = df.loc[~crossed]
+
+        if "timestamp" in df.columns:
+            timestamps = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+            if now is None:
+                now = datetime.now(UTC)
+            age = (now - timestamps).dt.total_seconds()
+            stale_mask = age > cfg.max_age_seconds
+            if stale_mask.any():
+                removals.extend(
+                    {
+                        "index": int(idx),
+                        "tenor": float(row.tenor),
+                        "strike": float(row.strike),
+                        "reason": "stale",
+                    }
+                    for idx, row in df.loc[stale_mask].iterrows()
+                )
+            df = df.loc[~stale_mask]
+
+        df = df.dropna(subset=["tenor", "strike", "mid_iv", "forward"])
+        if df.empty:
+            return CleanBoard(df, self._report(total, removals, retained=0))
+
+        option_type = df.get("option_type")
+        if option_type is None:
+            df["option_type"] = "CALL"
+        else:
+            df["option_type"] = option_type.fillna("CALL").str.upper()
+            df.loc[~df["option_type"].isin({"CALL", "PUT"}), "option_type"] = "CALL"
+
+        log_money = np.log(np.clip(df["strike"] / df["forward"], 1e-12, None))
+        bounds_low, bounds_high = cfg.log_money_bounds
+        out_of_bounds = (log_money < bounds_low) | (log_money > bounds_high)
+        if out_of_bounds.any():
+            removals.extend(
+                {
+                    "index": int(idx),
+                    "tenor": float(row.tenor),
+                    "strike": float(row.strike),
+                    "reason": "out_of_bounds",
+                }
+                for idx, row in df.loc[out_of_bounds].iterrows()
+            )
+        df = df.loc[~out_of_bounds].copy()
+
+        if df.empty:
+            return CleanBoard(df, self._report(total, removals, retained=0))
+
+        df["log_moneyness"] = log_money.loc[df.index]
+
+        rng = np.random.default_rng(seed)
+
+        residuals: List[Dict[str, Any]] = []
+        filtered_groups: List[pd.DataFrame] = []
+
+        for tenor, tenor_df in df.groupby("tenor", sort=True):
+            tenor_df = tenor_df.sort_values("log_moneyness").reset_index(drop=True)
+            bucket_ids = np.digitize(tenor_df["log_moneyness"], cfg.log_money_bins, right=True)
+            keep_mask = np.ones(len(tenor_df), dtype=bool)
+            for bucket in np.unique(bucket_ids):
+                bucket_mask = bucket_ids == bucket
+                bucket_values = tenor_df.loc[bucket_mask, "mid_iv"].to_numpy(dtype=float)
+                if bucket_values.size == 0:
+                    continue
+                median = float(np.median(bucket_values))
+                mad = float(np.median(np.abs(bucket_values - median)))
+                scaled = np.zeros_like(bucket_values)
+                if mad > 0.0:
+                    scaled = np.abs(bucket_values - median) / (1.4826 * mad)
+                else:
+                    scaled = np.abs(bucket_values - median)
+                residuals.append(
+                    {
+                        "tenor": float(tenor),
+                        "bucket": int(bucket),
+                        "median": median,
+                        "mad": mad,
+                    }
+                )
+                mask = scaled <= cfg.mad_threshold
+                if not np.all(mask):
+                    drop_indices = np.where(~mask)[0]
+                    rng_order = np.argsort(drop_indices)
+                    for local_idx in drop_indices[rng_order]:
+                        row = tenor_df.iloc[int(np.flatnonzero(bucket_mask)[local_idx])]
+                        removals.append(
+                            {
+                                "index": int(row.name),
+                                "tenor": float(row.tenor),
+                                "strike": float(row.strike),
+                                "reason": "outlier",
+                            }
+                        )
+                keep_mask[bucket_mask] &= mask
+            filtered_groups.append(tenor_df.loc[keep_mask])
+
+        if filtered_groups:
+            cleaned = pd.concat(filtered_groups, ignore_index=True)
+        else:
+            cleaned = pd.DataFrame(columns=df.columns)
+
+        cleaned = cleaned.reset_index(drop=True)
+        cleaned = cleaned.sort_values(["tenor", "strike", "option_type"]).reset_index(drop=True)
+
+        qc = self._report(total, removals, retained=len(cleaned))
+        qc["residuals"] = residuals
+
+        return CleanBoard(cleaned, qc)
+
+    def _empty_report(self) -> Dict[str, Any]:
+        return self._report(0, [], retained=0)
+
+    def _report(
+        self,
+        total: int,
+        removals: Sequence[Mapping[str, Any]],
+        *,
+        retained: int,
+    ) -> Dict[str, Any]:
+        counts: MutableMapping[str, int] = {
+            "total": int(total),
+            "retained": int(retained),
+            "dropped": int(total - retained),
+        }
+        reason_counts: Dict[str, int] = {}
+        for removal in removals:
+            reason = str(removal.get("reason", "other"))
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        counts.update({f"dropped_{reason}": count for reason, count in sorted(reason_counts.items())})
+        return {"counts": dict(counts), "removals": list(removals)}

--- a/options-pricing-engine/src/options_engine/calib/heston_qe.py
+++ b/options-pricing-engine/src/options_engine/calib/heston_qe.py
@@ -1,0 +1,149 @@
+"""Simplified Heston calibration using Andersen QE inspired objective."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional
+
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.optimize import least_squares
+
+from .boards import CleanBoard
+
+
+@dataclass(slots=True)
+class HestonConfig:
+    seeds: tuple[int, ...] = (0, 1)
+    tolerance: float = 1e-8
+    max_iterations: int = 100
+    tenors: Optional[List[float]] = None  # ``None`` => calibrate all
+
+
+@dataclass(slots=True)
+class HestonTenorResult:
+    tenor: float
+    params: Dict[str, float]
+    rmse: float
+    strikes: np.ndarray
+    market_vols: np.ndarray
+    model_vols: np.ndarray
+
+
+class HestonQECalibrator:
+    """Lightweight Heston calibration for cross-checking SABR."""
+
+    def __init__(self, config: Optional[HestonConfig] = None) -> None:
+        self._config = config or HestonConfig()
+
+    def calibrate(
+        self,
+        clean_board: CleanBoard,
+        *,
+        forward_curve: Mapping[float, float] | None = None,
+    ) -> List[HestonTenorResult]:
+        data = clean_board.quotes
+        if data.empty:
+            return []
+
+        results: List[HestonTenorResult] = []
+        tenors = set(self._config.tenors) if self._config.tenors else None
+
+        for tenor, group in data.groupby("tenor", sort=True):
+            if tenors is not None and float(tenor) not in tenors:
+                continue
+            if len(group) < 3:
+                continue
+            forward = self._resolve_forward(float(tenor), group, forward_curve)
+            result = self._calibrate_single_tenor(forward, float(tenor), group)
+            results.append(result)
+        return results
+
+    def _resolve_forward(
+        self,
+        tenor: float,
+        group,
+        forward_curve: Mapping[float, float] | None,
+    ) -> float:
+        if forward_curve is not None:
+            if tenor in forward_curve:
+                return float(forward_curve[tenor])
+            for key, value in forward_curve.items():
+                if np.isclose(key, tenor, atol=1e-9):
+                    return float(value)
+        return float(np.mean(group["forward"].to_numpy(dtype=float)))
+
+    def _calibrate_single_tenor(self, forward: float, tenor: float, group) -> HestonTenorResult:
+        strikes = group["strike"].to_numpy(dtype=float)
+        market_vols = group["mid_iv"].to_numpy(dtype=float)
+        log_m = np.log(np.clip(strikes / forward, 1e-12, None))
+
+        seeds = self._config.seeds or (0,)
+        best_rmse = float("inf")
+        best_theta: Optional[np.ndarray] = None
+        best_model = np.zeros_like(market_vols)
+
+        def objective(theta: ArrayLike) -> np.ndarray:
+            params = self._unpack(theta)
+            model = self._heston_proxy(log_m, tenor, params)
+            return model - market_vols
+
+        initial = np.array([np.log(np.mean(market_vols) ** 2), 0.1, 0.5, 0.0], dtype=float)
+
+        for seed in seeds:
+            theta0 = initial.copy()
+            if seed != 0:
+                rng = np.random.default_rng(seed)
+                theta0 += rng.normal(scale=0.25, size=theta0.size)
+            res = least_squares(
+                objective,
+                theta0,
+                xtol=self._config.tolerance,
+                ftol=self._config.tolerance,
+                gtol=self._config.tolerance,
+                max_nfev=self._config.max_iterations,
+            )
+            if not res.success:
+                continue
+            rmse = float(np.sqrt(np.mean(res.fun**2)))
+            if rmse < best_rmse:
+                best_rmse = rmse
+                best_theta = res.x.copy()
+                best_model = market_vols + res.fun
+
+        if best_theta is None:
+            raise RuntimeError(f"Heston calibration failed for tenor {tenor}")
+
+        params = self._format(best_theta)
+        return HestonTenorResult(
+            tenor=float(tenor),
+            params=params,
+            rmse=best_rmse,
+            strikes=strikes,
+            market_vols=market_vols,
+            model_vols=best_model,
+        )
+
+    def _unpack(self, theta: ArrayLike) -> Dict[str, float]:
+        theta = np.asarray(theta, dtype=float)
+        v0 = float(np.exp(theta[0]))
+        kappa = float(np.exp(theta[1]))
+        sigma = float(np.exp(theta[2]))
+        rho = float(np.tanh(theta[3]))
+        return {"v0": v0, "kappa": kappa, "sigma": sigma, "rho": rho}
+
+    def _format(self, theta: ArrayLike) -> Dict[str, float]:
+        params = self._unpack(theta)
+        return {key: float(value) for key, value in params.items()}
+
+    def _heston_proxy(self, log_m: np.ndarray, tenor: float, params: Mapping[str, float]) -> np.ndarray:
+        v0 = max(params["v0"], 1e-6)
+        kappa = max(params["kappa"], 1e-6)
+        sigma = max(params["sigma"], 1e-6)
+        rho = np.clip(params["rho"], -0.999, 0.999)
+        # Use a quadratic proxy in log-moneyness inspired by Andersen QE moments.
+        a = np.sqrt(v0)
+        b = sigma / (1.0 + kappa * tenor)
+        c = rho * sigma * np.sqrt(tenor)
+        vols = np.sqrt(np.maximum((a + b * log_m) ** 2 + c * log_m**2, 1e-8))
+        return vols

--- a/options-pricing-engine/src/options_engine/calib/sabr.py
+++ b/options-pricing-engine/src/options_engine/calib/sabr.py
@@ -1,0 +1,262 @@
+"""SABR calibration routines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.optimize import least_squares
+
+from .boards import CleanBoard
+
+
+@dataclass(slots=True)
+class SABRConfig:
+    beta: float = 0.5
+    fit_beta: bool = False
+    seeds: Tuple[int, ...] = (0, 1, 2)
+    tolerance: float = 1e-8
+    max_iterations: int = 200
+
+
+@dataclass(slots=True)
+class SABRTenorResult:
+    tenor: float
+    params: Dict[str, float]
+    rmse: float
+    strikes: np.ndarray
+    market_vols: np.ndarray
+    model_vols: np.ndarray
+
+
+class SABRCalibrator:
+    """Calibrate SABR parameters per tenor."""
+
+    def __init__(self, config: Optional[SABRConfig] = None) -> None:
+        self._config = config or SABRConfig()
+
+    def calibrate(
+        self,
+        clean_board: CleanBoard,
+        *,
+        forward_curve: Mapping[float, float] | None = None,
+    ) -> List[SABRTenorResult]:
+        data = clean_board.quotes
+        if data.empty:
+            return []
+
+        results: List[SABRTenorResult] = []
+        warm_start: Optional[np.ndarray] = None
+
+        for tenor, group in data.groupby("tenor", sort=True):
+            tenor_value = float(tenor)
+            strikes = group["strike"].to_numpy(dtype=float)
+            market_vols = group["mid_iv"].to_numpy(dtype=float)
+            if strikes.size < 3:
+                continue
+            forward = self._resolve_forward(tenor_value, group, forward_curve)
+            res = self._calibrate_single_tenor(
+                forward,
+                tenor_value,
+                strikes,
+                market_vols,
+                warm_start=warm_start,
+            )
+            results.append(res)
+            warm_start = self._pack_params(res.params)
+        return results
+
+    def _resolve_forward(
+        self,
+        tenor: float,
+        group,
+        forward_curve: Mapping[float, float] | None,
+    ) -> float:
+        if forward_curve is not None:
+            if tenor in forward_curve:
+                return float(forward_curve[tenor])
+            for key, value in forward_curve.items():
+                if np.isclose(key, tenor, atol=1e-9):
+                    return float(value)
+        forwards = group["forward"].to_numpy(dtype=float)
+        return float(np.mean(forwards))
+
+    def _calibrate_single_tenor(
+        self,
+        forward: float,
+        tenor: float,
+        strikes: np.ndarray,
+        market_vols: np.ndarray,
+        *,
+        warm_start: Optional[np.ndarray],
+    ) -> SABRTenorResult:
+        cfg = self._config
+
+        seeds: Sequence[int] = cfg.seeds or (0,)
+        best_rmse = float("inf")
+        best_result: Optional[Tuple[np.ndarray, np.ndarray]] = None
+
+        def objective(theta: np.ndarray) -> np.ndarray:
+            params = self._unpack_params(theta)
+            model = hagan_implied_volatility(
+                forward,
+                strikes,
+                tenor,
+                alpha=params["alpha"],
+                beta=params["beta"],
+                rho=params["rho"],
+                nu=params["nu"],
+            )
+            return model - market_vols
+
+        initial = self._initial_guess(forward, strikes, market_vols, warm_start)
+
+        for seed in seeds:
+            theta0 = initial.copy()
+            if seed != 0:
+                rng = np.random.default_rng(seed)
+                theta0 = theta0 + rng.normal(scale=0.25, size=theta0.size)
+            result = least_squares(
+                objective,
+                theta0,
+                xtol=cfg.tolerance,
+                ftol=cfg.tolerance,
+                gtol=cfg.tolerance,
+                max_nfev=cfg.max_iterations,
+            )
+            if not result.success:
+                continue
+            model_vols = market_vols + result.fun
+            rmse = float(np.sqrt(np.mean(result.fun**2)))
+            if rmse < best_rmse:
+                best_rmse = rmse
+                best_result = (result.x, model_vols)
+
+        if best_result is None:
+            raise RuntimeError(f"SABR calibration failed for tenor {tenor}")
+
+        params = self._format_params(best_result[0])
+        return SABRTenorResult(
+            tenor=float(tenor),
+            params=params,
+            rmse=best_rmse,
+            strikes=strikes.copy(),
+            market_vols=market_vols.copy(),
+            model_vols=best_result[1],
+        )
+
+    def _initial_guess(
+        self,
+        forward: float,
+        strikes: np.ndarray,
+        market_vols: np.ndarray,
+        warm_start: Optional[np.ndarray],
+    ) -> np.ndarray:
+        cfg = self._config
+        if warm_start is not None:
+            return warm_start.copy()
+        atm_index = int(np.argmin(np.abs(strikes - forward)))
+        atm_vol = float(market_vols[atm_index])
+        alpha = np.log(max(atm_vol * forward ** (1.0 - cfg.beta), 1e-4))
+        rho = np.arctanh(np.clip(0.0, -0.95, 0.95))
+        nu = np.log(0.5)
+        if cfg.fit_beta:
+            beta = np.log(cfg.beta / (1.0 - cfg.beta + 1e-12))
+            return np.array([alpha, rho, nu, beta], dtype=float)
+        return np.array([alpha, rho, nu], dtype=float)
+
+    def _pack_params(self, params: Mapping[str, float]) -> np.ndarray:
+        if self._config.fit_beta:
+            beta = params.get("beta", self._config.beta)
+            beta = np.clip(beta, 1e-6, 1.0 - 1e-6)
+            beta_theta = np.log(beta / (1.0 - beta))
+            return np.array([
+                np.log(params["alpha"]),
+                np.arctanh(params["rho"]),
+                np.log(params["nu"]),
+                beta_theta,
+            ], dtype=float)
+        return np.array(
+            [
+                np.log(params["alpha"]),
+                np.arctanh(params["rho"]),
+                np.log(params["nu"]),
+            ],
+            dtype=float,
+        )
+
+    def _unpack_params(self, theta: ArrayLike) -> Dict[str, float]:
+        theta = np.asarray(theta, dtype=float)
+        alpha = float(np.exp(theta[0]))
+        rho = float(np.tanh(theta[1]))
+        nu = float(np.exp(theta[2]))
+        beta = self._config.beta
+        if self._config.fit_beta:
+            beta = float(1.0 / (1.0 + np.exp(-theta[3])))
+        beta = float(np.clip(beta, 0.0, 1.0))
+        return {"alpha": alpha, "beta": beta, "rho": rho, "nu": nu}
+
+    def _format_params(self, theta: ArrayLike) -> Dict[str, float]:
+        params = self._unpack_params(theta)
+        return {key: float(value) for key, value in params.items()}
+
+
+def hagan_implied_volatility(
+    forward: float | np.ndarray,
+    strike: float | np.ndarray,
+    expiry: float,
+    *,
+    alpha: float,
+    beta: float,
+    rho: float,
+    nu: float,
+) -> np.ndarray:
+    if expiry <= 0.0:
+        raise ValueError("expiry must be positive")
+
+    F = np.asarray(forward, dtype=float)
+    K = np.asarray(strike, dtype=float)
+    beta = float(np.clip(beta, 0.0, 1.0))
+    rho = float(np.clip(rho, -0.999, 0.999))
+    alpha = float(max(alpha, 1e-12))
+    nu = float(max(nu, 1e-12))
+
+    F, K = np.broadcast_arrays(F, K)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        fk_beta = np.power(F * K, (1.0 - beta) / 2.0)
+        fk_beta = np.where(fk_beta <= 0.0, 1e-12, fk_beta)
+        log_fk = np.log(np.where(K == 0.0, 1.0, F / K))
+        z = (nu / alpha) * fk_beta * log_fk
+        sqrt_term = np.sqrt(1.0 - 2.0 * rho * z + z**2)
+        numerator = sqrt_term + z - rho
+        denominator = 1.0 - rho
+        x_z = np.log(np.where(numerator <= 0.0, 1.0, numerator / denominator))
+        small_z = np.abs(z) < 1e-12
+        z_over_x = np.where(small_z, 1.0, z / x_z)
+
+        one_minus_beta = 1.0 - beta
+        one_minus_beta_sq = one_minus_beta**2
+        log_fk_sq = log_fk**2
+        log_fk_quartic = log_fk_sq**2
+
+        term1 = alpha / (
+            fk_beta
+            * (
+                1.0
+                + (one_minus_beta_sq / 24.0) * log_fk_sq
+                + (one_minus_beta_sq**2 / 1920.0) * log_fk_quartic
+            )
+        )
+        term2 = z_over_x
+        term3 = 1.0 + (
+            ((one_minus_beta_sq / 24.0) * (alpha**2) / (fk_beta**2))
+            + (0.25 * rho * beta * nu * alpha) / fk_beta
+            + ((2.0 - 3.0 * rho**2) / 24.0) * nu**2
+        ) * expiry
+
+        implied = term1 * term2 * term3
+        implied = np.where(np.isnan(implied), alpha / (F ** (1.0 - beta)), implied)
+        implied = np.maximum(implied, 1e-4)
+    return implied

--- a/options-pricing-engine/src/options_engine/calib/select.py
+++ b/options-pricing-engine/src/options_engine/calib/select.py
@@ -1,0 +1,127 @@
+"""Model selection and volatility surface construction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+import pandas as pd
+
+from .boards import BoardCleaner, CleanBoard
+from .heston_qe import HestonQECalibrator, HestonTenorResult
+from .sabr import SABRCalibrator, SABRConfig, SABRTenorResult
+from .validators import NoArbitrageValidator, ValidationReport
+
+
+@dataclass(slots=True)
+class TenorSelection:
+    tenor: float
+    model: str
+    params: Dict[str, float]
+    rmse: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tenor": self.tenor,
+            "model": self.model,
+            "params": self.params,
+            "rmse": self.rmse,
+        }
+
+
+@dataclass(slots=True)
+class SurfaceBuildResult:
+    surface_id: str
+    clean_board: CleanBoard
+    qc: Dict[str, Any]
+    validation: ValidationReport
+    selections: List[TenorSelection]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "surface_id": self.surface_id,
+            "qc": self.qc,
+            "validation": self.validation.to_dict(),
+            "tenors": [selection.to_dict() for selection in self.selections],
+        }
+
+
+class SurfaceBuilder:
+    """End-to-end orchestration of the volatility surface calibration workflow."""
+
+    def __init__(
+        self,
+        *,
+        cleaner: Optional[BoardCleaner] = None,
+        sabr: Optional[SABRCalibrator] = None,
+        validator: Optional[NoArbitrageValidator] = None,
+        heston: Optional[HestonQECalibrator] = None,
+    ) -> None:
+        self._cleaner = cleaner or BoardCleaner()
+        self._sabr = sabr or SABRCalibrator(SABRConfig())
+        self._validator = validator or NoArbitrageValidator()
+        self._heston = heston or HestonQECalibrator()
+
+    def build(
+        self,
+        quotes: Iterable[Mapping[str, Any]],
+        *,
+        forward_curve: Mapping[float, float] | None = None,
+        now: Optional[pd.Timestamp] = None,
+        seed: int = 0,
+        enable_heston: bool = True,
+    ) -> SurfaceBuildResult:
+        clean = self._cleaner.ingest(quotes, now=now, seed=seed)
+        validation = self._validator.validate(clean)
+        if not validation.is_ok:
+            raise ValueError("arbitrage violations detected", validation.to_dict())
+
+        sabr_results = self._sabr.calibrate(clean, forward_curve=forward_curve)
+        if not sabr_results:
+            raise ValueError("no tenors available for calibration")
+
+        heston_results: List[HestonTenorResult] = []
+        if enable_heston:
+            try:
+                heston_results = self._heston.calibrate(clean, forward_curve=forward_curve)
+            except RuntimeError:
+                heston_results = []
+        heston_map = {result.tenor: result for result in heston_results}
+
+        selections: List[TenorSelection] = []
+        for result in sabr_results:
+            heston_result = heston_map.get(result.tenor)
+            best_model = "sabr"
+            best_params = result.params
+            best_rmse = result.rmse
+            if heston_result is not None and heston_result.rmse < best_rmse:
+                best_model = "heston_qe"
+                best_params = heston_result.params
+                best_rmse = heston_result.rmse
+            selections.append(
+                TenorSelection(
+                    tenor=result.tenor,
+                    model=best_model,
+                    params={key: float(val) for key, val in best_params.items()},
+                    rmse=float(best_rmse),
+                )
+            )
+
+        surface_id = self._compute_surface_id(clean, selections)
+        qc = {
+            "board": clean.qc,
+            "rmse": {selection.tenor: selection.rmse for selection in selections},
+            "models": {selection.tenor: selection.model for selection in selections},
+        }
+        return SurfaceBuildResult(surface_id, clean, qc, validation, selections)
+
+    def _compute_surface_id(self, clean: CleanBoard, selections: Sequence[TenorSelection]) -> str:
+        payload = {
+            "quotes": clean.to_records(),
+            "selections": [selection.to_dict() for selection in selections],
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        return digest[:32]

--- a/options-pricing-engine/src/options_engine/calib/validators.py
+++ b/options-pricing-engine/src/options_engine/calib/validators.py
@@ -1,0 +1,243 @@
+"""No-arbitrage validation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+import math
+import numpy as np
+import pandas as pd
+
+from .boards import CleanBoard
+
+_PARITY_TOL = 1e-8
+
+
+@dataclass(slots=True)
+class Violation:
+    """Describes a single arbitrage violation."""
+
+    kind: str
+    tenor: float
+    strike: float
+    detail: Dict[str, float]
+
+
+@dataclass(slots=True)
+class ValidationReport:
+    """Outcome of the arbitrage validation."""
+
+    violations: List[Violation]
+
+    @property
+    def is_ok(self) -> bool:
+        return not self.violations
+
+    def reasons(self) -> List[str]:
+        return [violation.kind for violation in self.violations]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "is_ok": self.is_ok,
+            "violations": [
+                {"kind": v.kind, "tenor": v.tenor, "strike": v.strike, "detail": v.detail}
+                for v in self.violations
+            ],
+        }
+
+
+class NoArbitrageValidator:
+    """Validate cleaned quote boards or model surfaces for arbitrage."""
+
+    def __init__(self, parity_tol: float = _PARITY_TOL) -> None:
+        self._parity_tol = float(parity_tol)
+
+    def validate(self, board: CleanBoard | pd.DataFrame) -> ValidationReport:
+        if isinstance(board, CleanBoard):
+            data = board.quotes.copy()
+        else:
+            data = board.copy()
+        if data.empty:
+            return ValidationReport([])
+
+        required = {"tenor", "strike", "mid_iv", "forward", "option_type"}
+        missing = required - set(data.columns)
+        if missing:
+            raise KeyError(f"missing columns for validation: {sorted(missing)}")
+
+        # Normalise types
+        data["option_type"] = data["option_type"].str.upper()
+        data = data.sort_values(["tenor", "strike", "option_type"]).reset_index(drop=True)
+
+        violations: List[Violation] = []
+
+        for tenor, tenor_df in data.groupby("tenor", sort=True):
+            forward = float(np.mean(tenor_df["forward"].to_numpy(dtype=float)))
+            discount = float(np.mean(tenor_df.get("discount", 1.0)))
+            strikes, call_prices = self._call_prices(tenor_df, forward, discount)
+            violations.extend(self._check_butterfly(tenor, strikes, call_prices))
+            parity_violations = self._check_parity(tenor_df, forward, discount)
+            violations.extend(parity_violations)
+
+        violations.extend(self._check_calendar(data))
+
+        return ValidationReport(violations)
+
+    def _call_prices(
+        self, tenor_df: pd.DataFrame, forward: float, discount: float
+    ) -> tuple[np.ndarray, np.ndarray]:
+        strikes: Dict[float, Dict[str, float]] = {}
+        for _, row in tenor_df.sort_values(["strike", "option_type"]).iterrows():
+            strike = float(row["strike"])
+            expiry = float(row["tenor"])
+            sigma = float(row["mid_iv"])
+            opt_type = row["option_type"]
+            price = _black_price_single(opt_type, forward, strike, expiry, sigma, discount)
+            entry = strikes.setdefault(strike, {"call": math.nan, "put": math.nan})
+            if opt_type == "PUT":
+                entry["put"] = price
+            else:
+                entry["call"] = price
+        strikes_array: List[float] = []
+        call_prices: List[float] = []
+        for strike in sorted(strikes):
+            entry = strikes[strike]
+            if not math.isnan(entry["call"]):
+                call_price = entry["call"]
+            elif not math.isnan(entry["put"]):
+                call_price = entry["put"] + discount * (forward - strike)
+            else:
+                continue
+            strikes_array.append(strike)
+            call_prices.append(call_price)
+        return np.array(strikes_array, dtype=float), np.array(call_prices, dtype=float)
+
+    def _check_butterfly(self, tenor: float, strikes: np.ndarray, call_prices: np.ndarray) -> List[Violation]:
+        violations: List[Violation] = []
+        order = np.argsort(strikes)
+        strikes = strikes[order]
+        call_prices = call_prices[order]
+        if strikes.size < 3:
+            return violations
+        second_diff = call_prices[:-2] - 2.0 * call_prices[1:-1] + call_prices[2:]
+        for idx, value in enumerate(second_diff):
+            if value < -1e-8:
+                violations.append(
+                    Violation(
+                        kind="butterfly",
+                        tenor=float(tenor),
+                        strike=float(strikes[idx + 1]),
+                        detail={"second_diff": float(value)},
+                    )
+                )
+        return violations
+
+    def _check_calendar(self, data: pd.DataFrame) -> List[Violation]:
+        violations: List[Violation] = []
+        grouped = data.groupby(["strike", "option_type"], sort=True)
+        for (strike, option_type), group in grouped:
+            sorted_group = group.sort_values("tenor")
+            forward = float(np.mean(sorted_group["forward"].to_numpy(dtype=float)))
+            discount = float(np.mean(sorted_group.get("discount", 1.0)))
+            prices = _black_price_array(
+                np.full(len(sorted_group), option_type),
+                forward,
+                np.full(len(sorted_group), float(strike)),
+                sorted_group["tenor"].to_numpy(dtype=float),
+                sorted_group["mid_iv"].to_numpy(dtype=float),
+                discount,
+            )
+            diffs = np.diff(prices)
+            for tenor_low, value in zip(sorted_group["tenor"].to_numpy(dtype=float)[:-1], diffs):
+                if value < -1e-8:
+                    violations.append(
+                        Violation(
+                            kind="calendar",
+                            tenor=float(tenor_low),
+                            strike=float(strike),
+                            detail={"delta": float(value)},
+                        )
+                    )
+        return violations
+
+    def _check_parity(self, tenor_df: pd.DataFrame, forward: float, discount: float) -> List[Violation]:
+        parity_violations: List[Violation] = []
+        grouped = tenor_df.groupby("strike")
+        for strike, group in grouped:
+            types = group["option_type"].str.upper()
+            if {"CALL", "PUT"} <= set(types):
+                quotes = group.sort_values("option_type")
+                prices = _black_price_array(
+                    quotes["option_type"].to_numpy(),
+                    forward,
+                    np.full(len(quotes), float(strike)),
+                    np.full(len(quotes), float(quotes["tenor"].iloc[0])),
+                    quotes["mid_iv"].to_numpy(dtype=float),
+                    discount,
+                )
+                parity = prices[0] - prices[1] - discount * (forward - float(strike))
+                if abs(float(parity)) > self._parity_tol:
+                    parity_violations.append(
+                        Violation(
+                            kind="parity",
+                            tenor=float(quotes["tenor"].iloc[0]),
+                            strike=float(strike),
+                            detail={"parity": float(parity)},
+                        )
+                    )
+        return parity_violations
+
+
+def _black_price_array(
+    option_types: Iterable[str],
+    forward: float,
+    strikes: np.ndarray,
+    expiry: np.ndarray,
+    vols: np.ndarray,
+    discount: float,
+) -> np.ndarray:
+    option_types = np.asarray(list(option_types))
+    strikes = np.asarray(strikes, dtype=float)
+    expiry = np.asarray(expiry, dtype=float)
+    vols = np.asarray(vols, dtype=float)
+    discount = float(discount)
+    prices = np.empty_like(strikes, dtype=float)
+    for idx, (opt_type, K, T, sigma) in enumerate(zip(option_types, strikes, expiry, vols)):
+        prices[idx] = _black_price_single(opt_type, forward, K, T, sigma, discount)
+    return prices
+
+
+def _black_price_single(
+    option_type: str,
+    forward: float,
+    strike: float,
+    expiry: float,
+    sigma: float,
+    discount: float,
+) -> float:
+    sigma = max(float(sigma), 1e-4)
+    expiry = max(float(expiry), 1e-6)
+    call_price = _black_call_price(forward, strike, expiry, sigma, discount)
+    if option_type == "PUT":
+        return call_price - discount * (forward - strike)
+    return call_price
+
+
+def _black_call_price(forward: float, strike: float, expiry: float, sigma: float, discount: float) -> float:
+    if sigma <= 0.0:
+        sigma = 1e-4
+    if expiry <= 0.0:
+        expiry = 1e-6
+    vol_sqrt_t = sigma * np.sqrt(expiry)
+    if vol_sqrt_t < 1e-8:
+        intrinsic = max(forward - strike, 0.0)
+        return discount * intrinsic
+    d1 = (np.log(forward / strike) + 0.5 * vol_sqrt_t**2) / vol_sqrt_t
+    d2 = d1 - vol_sqrt_t
+    call = discount * (forward * _norm_cdf(d1) - strike * _norm_cdf(d2))
+    return float(call)
+
+
+def _norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))

--- a/options-pricing-engine/src/options_engine/tests/calib/test_surface_pipeline.py
+++ b/options-pricing-engine/src/options_engine/tests/calib/test_surface_pipeline.py
@@ -1,0 +1,152 @@
+"""Integration tests for the volatility surface calibration pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List
+
+import numpy as np
+import pytest
+
+from options_engine.calib import (
+    BoardCleaner,
+    HestonQECalibrator,
+    SABRCalibrator,
+    SurfaceBuilder,
+)
+from options_engine.calib.heston_qe import HestonConfig
+from options_engine.calib.sabr import SABRConfig, hagan_implied_volatility
+from options_engine.calib.select import SurfaceBuildResult
+
+
+def _synthetic_board() -> List[Dict[str, float]]:
+    tenors = [0.25, 0.5, 1.0]
+    strikes = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
+    forward = 100.0
+    base_params = {
+        0.25: {"alpha": 0.25, "beta": 0.5, "rho": -0.2, "nu": 0.6},
+        0.5: {"alpha": 0.22, "beta": 0.5, "rho": -0.1, "nu": 0.5},
+        1.0: {"alpha": 0.2, "beta": 0.5, "rho": 0.0, "nu": 0.45},
+    }
+    board: List[Dict[str, float]] = []
+    now = datetime.now(timezone.utc)
+    for tenor in tenors:
+        params = base_params[tenor]
+        vols = hagan_implied_volatility(
+            forward,
+            strikes,
+            tenor,
+            alpha=params["alpha"],
+            beta=params["beta"],
+            rho=params["rho"],
+            nu=params["nu"],
+        )
+        noise = np.linspace(-0.002, 0.002, len(strikes))
+        for strike, vol, epsilon in zip(strikes, vols, noise):
+            for opt_type in ("CALL", "PUT"):
+                board.append(
+                    {
+                        "tenor": tenor,
+                        "strike": float(strike),
+                        "mid_iv": float(vol + epsilon),
+                        "forward": forward,
+                        "option_type": opt_type,
+                        "timestamp": now - timedelta(seconds=10),
+                    }
+                )
+    return board
+
+
+def _arbitrage_board() -> List[Dict[str, float]]:
+    board = _synthetic_board()
+    for quote in board:
+        if quote["tenor"] == 0.25 and quote["strike"] == 100.0:
+            if quote["option_type"] == "CALL":
+                quote["mid_iv"] *= 1.5
+            else:
+                quote["mid_iv"] *= 0.2
+    return board
+
+
+def _heston_friendly_board() -> List[Dict[str, float]]:
+    tenors = [0.25, 0.5]
+    strikes = np.array([90.0, 100.0, 110.0, 120.0])
+    forward = 105.0
+    board: List[Dict[str, float]] = []
+    params = {"v0": 0.04, "kappa": 1.5, "sigma": 0.7, "rho": -0.7}
+    now = datetime.now(timezone.utc)
+    for tenor in tenors:
+        log_m = np.log(strikes / forward)
+        vols = _heston_proxy(log_m, tenor, params)
+        for strike, vol in zip(strikes, vols):
+            for opt_type in ("CALL", "PUT"):
+                board.append(
+                    {
+                        "tenor": tenor,
+                        "strike": float(strike),
+                        "mid_iv": float(vol),
+                        "forward": forward,
+                        "option_type": opt_type,
+                        "timestamp": now - timedelta(seconds=5),
+                    }
+                )
+    return board
+
+
+def _heston_proxy(log_m: np.ndarray, tenor: float, params: Dict[str, float]) -> np.ndarray:
+    v0 = params["v0"]
+    kappa = params["kappa"]
+    sigma = params["sigma"]
+    rho = params["rho"]
+    a = np.sqrt(v0)
+    b = sigma / (1.0 + kappa * tenor)
+    c = rho * sigma * np.sqrt(tenor)
+    vols = np.sqrt(np.maximum((a + b * log_m) ** 2 + c * log_m**2, 1e-8))
+    return vols
+
+
+@pytest.fixture()
+def builder() -> SurfaceBuilder:
+    return SurfaceBuilder()
+
+
+def test_golden_board_calibration(builder: SurfaceBuilder) -> None:
+    board = _synthetic_board()
+    result = builder.build(board, seed=7)
+
+    assert isinstance(result, SurfaceBuildResult)
+    assert result.validation.is_ok
+    assert len(result.selections) == 3
+    for selection in result.selections:
+        assert selection.model == "sabr"
+        assert selection.rmse <= 0.0075
+
+
+def test_arbitrage_detection_blocks(builder: SurfaceBuilder) -> None:
+    board = _arbitrage_board()
+    with pytest.raises(ValueError) as excinfo:
+        builder.build(board, seed=1)
+    assert "parity" in str(excinfo.value).lower()
+
+
+def test_pipeline_determinism(builder: SurfaceBuilder) -> None:
+    board = _synthetic_board()
+    first = builder.build(board, seed=13)
+    second = builder.build(board, seed=13)
+    assert first.surface_id == second.surface_id
+    assert [sel.params for sel in first.selections] == [sel.params for sel in second.selections]
+
+
+def test_heston_cross_check_selection() -> None:
+    board = _heston_friendly_board()
+    cleaner = BoardCleaner()
+    sabr = SABRCalibrator(SABRConfig(beta=0.3))
+    heston = HestonQECalibrator(HestonConfig(tenors=[0.25]))
+    builder = SurfaceBuilder(cleaner=cleaner, sabr=sabr, heston=heston)
+    result = builder.build(board, seed=3)
+
+    assert any(selection.model == "heston_qe" for selection in result.selections)
+    heston_rmses = {sel.tenor: sel.rmse for sel in result.selections if sel.model == "heston_qe"}
+    sabr_rmses = {sel.tenor: sel.rmse for sel in result.selections if sel.model == "sabr"}
+    for tenor, rmse in heston_rmses.items():
+        assert rmse <= sabr_rmses.get(tenor, float("inf"))


### PR DESCRIPTION
## Summary
- add a dedicated `options_engine.calib` package covering quote cleaning, no-arbitrage validation, SABR and Heston calibration, and surface selection with deterministic hashing
- provide integration tests for the full calibration pipeline including arbitrage gating, determinism, and Heston cross-checking
- extend the quote API schema to accept optional surface handles and echo the resolved surface id in responses

## Testing
- pytest -q src/options_engine/tests/calib

------
https://chatgpt.com/codex/tasks/task_e_68d621274e7883338700b82cc682b383