### PR TITLE
Add Monte Carlo Greek estimators and stability safeguards

### DIFF
--- a/options-pricing-engine/src/options_engine/core/models.py
+++ b/options-pricing-engine/src/options_engine/core/models.py
@@ -92,3 +92,5 @@ class PricingResult:
     capsule_id: Optional[str] = None
     replay_capsule: Optional["ReplayCapsule"] = None
     control_variate_report: Optional[Dict[str, float | bool | None]] = None
+    ci_greeks: Optional[Dict[str, Dict[str, float]]] = None
+    greeks_meta: Optional[Dict[str, Dict[str, object]]] = None

--- a/options-pricing-engine/src/options_engine/greeks/__init__.py
+++ b/options-pricing-engine/src/options_engine/greeks/__init__.py
@@ -1,0 +1,43 @@
+"""Greek estimation utilities for Monte Carlo pricing."""
+
+from .estimators import (
+    aggregate_statistics,
+    finite_difference_delta,
+    finite_difference_gamma,
+    finite_difference_rho,
+    finite_difference_vega,
+    pathwise_delta,
+    pathwise_gamma,
+    pathwise_vega,
+    rho_likelihood_ratio,
+)
+from .stability import (
+    CI_Z_VALUE,
+    LOG_MONEYNESS_BOUND,
+    SIGMA_FLOOR,
+    TAU_FLOOR,
+    clamp_log_moneyness,
+    contributions_finite,
+    is_estimate_unstable,
+    standard_error,
+)
+
+__all__ = [
+    "aggregate_statistics",
+    "finite_difference_delta",
+    "finite_difference_gamma",
+    "finite_difference_rho",
+    "finite_difference_vega",
+    "pathwise_delta",
+    "pathwise_gamma",
+    "pathwise_vega",
+    "rho_likelihood_ratio",
+    "CI_Z_VALUE",
+    "LOG_MONEYNESS_BOUND",
+    "SIGMA_FLOOR",
+    "TAU_FLOOR",
+    "clamp_log_moneyness",
+    "contributions_finite",
+    "is_estimate_unstable",
+    "standard_error",
+]

--- a/options-pricing-engine/src/options_engine/greeks/estimators.py
+++ b/options-pricing-engine/src/options_engine/greeks/estimators.py
@@ -1,0 +1,392 @@
+"""Monte Carlo greek estimators and finite-difference fallbacks."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+
+from options_engine.core.models import MarketData, OptionContract, OptionType
+
+from .stability import (
+    CI_Z_VALUE,
+    SIGMA_FLOOR,
+    clamp_log_moneyness,
+    clamp_sigma,
+    clamp_tau,
+    contributions_finite,
+    guard_against_pathologies,
+    half_width,
+    safe_spot,
+    standard_error,
+)
+
+
+@dataclass(slots=True)
+class GreekSummary:
+    """Container representing a Monte Carlo greek estimate."""
+
+    value: float
+    standard_error: float
+    half_width_abs: float
+    contributions: np.ndarray
+
+
+def aggregate_statistics(contributions: np.ndarray) -> GreekSummary:
+    """Aggregate an array of per-path contributions into summary statistics."""
+
+    sample = np.asarray(contributions, dtype=float)
+    if sample.size == 0:
+        return GreekSummary(value=0.0, standard_error=math.inf, half_width_abs=math.inf, contributions=sample)
+    estimate = float(np.mean(sample))
+    se = standard_error(sample)
+    hw = half_width(se, CI_Z_VALUE)
+    return GreekSummary(value=estimate, standard_error=se, half_width_abs=hw, contributions=sample)
+
+
+def _indicator(contract: OptionContract, terminal_prices: np.ndarray) -> np.ndarray:
+    if contract.option_type is OptionType.CALL:
+        return np.greater(terminal_prices, contract.strike_price)
+    return np.less(terminal_prices, contract.strike_price)
+
+
+def pathwise_delta(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    discount_factor: float,
+    terminal_prices: np.ndarray,
+) -> np.ndarray:
+    """Return per-path delta contributions using the pathwise method."""
+
+    indicator = _indicator(contract, terminal_prices)
+    spot = safe_spot(market_data.spot_price)
+    contributions = discount_factor * np.where(indicator, terminal_prices / spot, 0.0)
+    if contract.option_type is OptionType.PUT:
+        contributions = -contributions
+    return contributions
+
+
+def pathwise_gamma(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    discount_factor: float,
+    terminal_prices: np.ndarray,
+    volatility: float,
+    time_to_expiry: float,
+) -> np.ndarray:
+    """Return per-path gamma contributions via mixed pathwise / LR estimator."""
+
+    delta_paths = pathwise_delta(
+        contract,
+        market_data,
+        discount_factor=discount_factor,
+        terminal_prices=terminal_prices,
+    )
+    tau = clamp_tau(time_to_expiry)
+    sigma = clamp_sigma(volatility)
+    sigma_sq = sigma**2
+    if tau <= 0.0 or sigma_sq <= 0.0:
+        return np.zeros_like(delta_paths)
+    log_ratio = np.log(np.maximum(terminal_prices, 1e-16) / safe_spot(market_data.spot_price))
+    log_ratio = clamp_log_moneyness(log_ratio)
+    score_s0 = (log_ratio - (market_data.risk_free_rate - market_data.dividend_yield + 0.5 * sigma_sq) * tau) / (
+        sigma_sq * tau * safe_spot(market_data.spot_price)
+    )
+    contributions = delta_paths * score_s0
+    return contributions
+
+
+def pathwise_vega(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    discount_factor: float,
+    terminal_prices: np.ndarray,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+) -> np.ndarray:
+    """Return per-path vega contributions using the pathwise method."""
+
+    indicator = _indicator(contract, terminal_prices)
+    tau = clamp_tau(time_to_expiry)
+    sigma = clamp_sigma(volatility)
+    sqrt_tau = math.sqrt(tau)
+    sensitivity_term = terminal_prices * (sqrt_tau * draws - sigma * tau)
+    contributions = discount_factor * np.where(indicator, sensitivity_term, 0.0)
+    if contract.option_type is OptionType.PUT:
+        contributions = -contributions
+    return contributions / 100.0
+
+
+def theta_likelihood_ratio(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    payoff: np.ndarray,
+    discount_factor: float,
+    terminal_prices: np.ndarray,
+    volatility: float,
+    time_to_expiry: float,
+) -> np.ndarray:
+    """Return per-path theta contributions using the LR/score-function method."""
+
+    tau = clamp_tau(time_to_expiry)
+    sigma = clamp_sigma(volatility)
+    sigma_sq = sigma**2
+    spot = safe_spot(market_data.spot_price)
+    log_ratio = clamp_log_moneyness(np.log(np.maximum(terminal_prices, 1e-16) / spot))
+    drift = (
+        market_data.risk_free_rate
+        - market_data.dividend_yield
+        - 0.5 * sigma_sq
+    )
+    deviation = log_ratio - drift * tau
+    score_tau = (
+        -0.5 / tau
+        + (deviation**2 + 2.0 * deviation * drift * tau) / (2.0 * sigma_sq * tau**2)
+    )
+    discount_derivative = -market_data.risk_free_rate * discount_factor
+    contributions = payoff * (discount_factor * score_tau + discount_derivative)
+    return contributions / 365.0
+
+
+def rho_likelihood_ratio(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    payoff: np.ndarray,
+    discount_factor: float,
+    terminal_prices: np.ndarray,
+    volatility: float,
+    time_to_expiry: float,
+) -> np.ndarray:
+    """Return per-path rho contributions using the LR/score-function method."""
+
+    tau = clamp_tau(time_to_expiry)
+    sigma = clamp_sigma(volatility)
+    sigma_sq = sigma**2
+    spot = safe_spot(market_data.spot_price)
+    log_ratio = clamp_log_moneyness(np.log(np.maximum(terminal_prices, 1e-16) / spot))
+    drift = (
+        market_data.risk_free_rate
+        - market_data.dividend_yield
+        - 0.5 * sigma_sq
+    )
+    deviation = log_ratio - drift * tau
+    score_r = deviation / sigma_sq
+    discount_derivative = -tau * discount_factor
+    contributions = payoff * (discount_factor * score_r + discount_derivative)
+    return contributions / 100.0
+
+
+def simulate_terminal_prices(
+    spot: float,
+    market_data: MarketData,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+) -> np.ndarray:
+    """Simulate terminal prices for the supplied parameters using common draws."""
+
+    tau = max(float(time_to_expiry), 0.0)
+    if tau == 0.0:
+        return np.full_like(draws, fill_value=spot, dtype=float)
+    sigma = max(float(volatility), 0.0)
+    sqrt_tau = math.sqrt(tau)
+    drift = (market_data.risk_free_rate - market_data.dividend_yield - 0.5 * sigma**2) * tau
+    diffusion = sigma * sqrt_tau * draws
+    return float(spot) * np.exp(drift + diffusion)
+
+
+def _payoff(contract: OptionContract, terminal_prices: np.ndarray) -> np.ndarray:
+    if contract.option_type is OptionType.CALL:
+        return np.maximum(terminal_prices - contract.strike_price, 0.0)
+    return np.maximum(contract.strike_price - terminal_prices, 0.0)
+
+
+def finite_difference_delta(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+    discounted_payoffs: np.ndarray,
+) -> GreekSummary:
+    spot = market_data.spot_price
+    bump = max(1e-4 * spot, 1e-6)
+    up_spot = spot + bump
+    down_spot = max(spot - bump, 1e-6)
+    discount_factor = math.exp(-market_data.risk_free_rate * time_to_expiry)
+    up_terminal = simulate_terminal_prices(up_spot, market_data, volatility, time_to_expiry, draws)
+    down_terminal = simulate_terminal_prices(down_spot, market_data, volatility, time_to_expiry, draws)
+    up_payoff = _payoff(contract, up_terminal)
+    down_payoff = _payoff(contract, down_terminal)
+    up_disc = discount_factor * up_payoff
+    down_disc = discount_factor * down_payoff
+    h_up = up_spot - spot
+    h_down = spot - down_spot
+    if h_up <= 0.0 and h_down <= 0.0:
+        contributions = np.zeros_like(discounted_payoffs)
+    elif h_down <= 0.0:
+        contributions = (up_disc - discounted_payoffs) / h_up
+    elif h_up <= 0.0:
+        contributions = (discounted_payoffs - down_disc) / h_down
+    else:
+        contributions = (up_disc - down_disc) / (h_up + h_down)
+    return aggregate_statistics(contributions)
+
+
+def finite_difference_gamma(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+    discounted_payoffs: np.ndarray,
+) -> GreekSummary:
+    spot = market_data.spot_price
+    bump = max(1e-4 * spot, 1e-6)
+    up_spot = spot + bump
+    down_spot = max(spot - bump, 1e-6)
+    discount_factor = math.exp(-market_data.risk_free_rate * time_to_expiry)
+    up_terminal = simulate_terminal_prices(up_spot, market_data, volatility, time_to_expiry, draws)
+    down_terminal = simulate_terminal_prices(down_spot, market_data, volatility, time_to_expiry, draws)
+    up_payoff = _payoff(contract, up_terminal)
+    down_payoff = _payoff(contract, down_terminal)
+    up_disc = discount_factor * up_payoff
+    down_disc = discount_factor * down_payoff
+    h_up = up_spot - spot
+    h_down = spot - down_spot
+    if h_up <= 0.0 or h_down <= 0.0:
+        contributions = np.zeros_like(discounted_payoffs)
+    else:
+        numerator = h_down * up_disc - (h_up + h_down) * discounted_payoffs + h_up * down_disc
+        contributions = 2.0 * numerator / (h_up * h_down * (h_up + h_down))
+    return aggregate_statistics(contributions)
+
+
+def finite_difference_vega(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+    discounted_payoffs: np.ndarray,
+) -> GreekSummary:
+    sigma = volatility
+    bump = max(1e-4 * sigma, 1e-6)
+    up_sigma = sigma + bump
+    down_sigma = max(sigma - bump, SIGMA_FLOOR)
+    discount_factor = math.exp(-market_data.risk_free_rate * time_to_expiry)
+    up_terminal = simulate_terminal_prices(market_data.spot_price, market_data, up_sigma, time_to_expiry, draws)
+    down_terminal = simulate_terminal_prices(market_data.spot_price, market_data, down_sigma, time_to_expiry, draws)
+    up_disc = discount_factor * _payoff(contract, up_terminal)
+    down_disc = discount_factor * _payoff(contract, down_terminal)
+    h_up = up_sigma - sigma
+    h_down = sigma - down_sigma
+    if h_up <= 0.0 and h_down <= 0.0:
+        contributions = np.zeros_like(discounted_payoffs)
+    elif h_down <= 0.0:
+        contributions = (up_disc - discounted_payoffs) / h_up
+    elif h_up <= 0.0:
+        contributions = (discounted_payoffs - down_disc) / h_down
+    else:
+        contributions = (up_disc - down_disc) / (h_up + h_down)
+    return aggregate_statistics(contributions / 100.0)
+
+
+def finite_difference_theta(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+    discounted_payoffs: np.ndarray,
+) -> GreekSummary:
+    tau = time_to_expiry
+    bump = max(1e-4 * tau, 1e-7)
+    up_tau = clamp_tau(tau + bump)
+    down_tau = clamp_tau(max(tau - bump, 0.0))
+    up_discount = math.exp(-market_data.risk_free_rate * up_tau)
+    down_discount = math.exp(-market_data.risk_free_rate * down_tau)
+    up_terminal = simulate_terminal_prices(market_data.spot_price, market_data, volatility, up_tau, draws)
+    down_terminal = simulate_terminal_prices(market_data.spot_price, market_data, volatility, down_tau, draws)
+    up_disc = up_discount * _payoff(contract, up_terminal)
+    down_disc = down_discount * _payoff(contract, down_terminal)
+    h_up = up_tau - time_to_expiry
+    h_down = time_to_expiry - down_tau
+    denominator = h_up + h_down
+    if denominator <= 0.0:
+        contributions = np.zeros_like(discounted_payoffs)
+    elif h_down <= 0.0:
+        contributions = (up_disc - discounted_payoffs) / h_up
+    elif h_up <= 0.0:
+        contributions = (discounted_payoffs - down_disc) / h_down
+    else:
+        contributions = (up_disc - down_disc) / denominator
+    return aggregate_statistics(contributions / 365.0)
+
+
+def finite_difference_rho(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+    discounted_payoffs: np.ndarray,
+) -> GreekSummary:
+    rate = market_data.risk_free_rate
+    bump = 1e-6
+    up_rate = rate + bump
+    down_rate = rate - bump
+    up_market = MarketData(
+        spot_price=market_data.spot_price,
+        risk_free_rate=up_rate,
+        dividend_yield=market_data.dividend_yield,
+    )
+    down_market = MarketData(
+        spot_price=market_data.spot_price,
+        risk_free_rate=down_rate,
+        dividend_yield=market_data.dividend_yield,
+    )
+    up_discount = math.exp(-up_rate * time_to_expiry)
+    down_discount = math.exp(-down_rate * time_to_expiry)
+    up_terminal = simulate_terminal_prices(market_data.spot_price, up_market, volatility, time_to_expiry, draws)
+    down_terminal = simulate_terminal_prices(market_data.spot_price, down_market, volatility, time_to_expiry, draws)
+    up_disc = up_discount * _payoff(contract, up_terminal)
+    down_disc = down_discount * _payoff(contract, down_terminal)
+    h_up = up_rate - rate
+    h_down = rate - down_rate
+    if h_up <= 0.0 and h_down <= 0.0:
+        contributions = np.zeros_like(discounted_payoffs)
+    elif h_down <= 0.0:
+        contributions = (up_disc - discounted_payoffs) / h_up
+    elif h_up <= 0.0:
+        contributions = (discounted_payoffs - down_disc) / h_down
+    else:
+        contributions = (up_disc - down_disc) / (h_up + h_down)
+    return aggregate_statistics(contributions / 100.0)
+
+
+def ensure_fd_inputs(
+    contract: OptionContract,
+    market_data: MarketData,
+    *,
+    volatility: float,
+    time_to_expiry: float,
+    draws: np.ndarray,
+    discounted_payoffs: np.ndarray,
+) -> None:
+    """Validate FD harness inputs to ensure deterministic behaviour."""
+
+    guard_against_pathologies([draws, discounted_payoffs])

--- a/options-pricing-engine/src/options_engine/greeks/stability.py
+++ b/options-pricing-engine/src/options_engine/greeks/stability.py
@@ -1,0 +1,81 @@
+"""Stability guards and helper utilities for Monte Carlo Greeks."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+import numpy as np
+
+CI_Z_VALUE = 1.96
+TAU_FLOOR = 1e-6
+SIGMA_FLOOR = 1e-4
+LOG_MONEYNESS_BOUND = 4.0
+SPOT_FLOOR = 1e-12
+
+
+def clamp_tau(value: float) -> float:
+    """Apply the maturity epsilon policy."""
+
+    return max(float(value), TAU_FLOOR)
+
+
+def clamp_sigma(value: float) -> float:
+    """Apply the volatility epsilon policy."""
+
+    return max(float(value), SIGMA_FLOOR)
+
+
+def clamp_log_moneyness(values: np.ndarray) -> np.ndarray:
+    """Clamp log-moneyness style terms to avoid extreme tails."""
+
+    return np.clip(values, -LOG_MONEYNESS_BOUND, LOG_MONEYNESS_BOUND)
+
+
+def safe_spot(value: float) -> float:
+    """Return a strictly positive spot used in denominators."""
+
+    return max(float(value), SPOT_FLOOR)
+
+
+def contributions_finite(contributions: np.ndarray) -> bool:
+    """Return True when all per-path contributions are finite."""
+
+    return bool(np.isfinite(contributions).all())
+
+
+def standard_error(contributions: np.ndarray) -> float:
+    """Compute the standard error of a set of contributions."""
+
+    sample = np.asarray(contributions, dtype=float)
+    if sample.size <= 1:
+        return 0.0
+    sample_std = float(np.std(sample, ddof=1))
+    if not math.isfinite(sample_std):
+        return math.inf
+    return sample_std / math.sqrt(sample.size)
+
+
+def half_width(se: float, z_value: float = CI_Z_VALUE) -> float:
+    """Return the half-width of the two-sided confidence interval."""
+
+    return float(abs(z_value) * se)
+
+
+def is_estimate_unstable(value: float, half_width_abs: float, price: float, *, threshold: float = 0.2) -> bool:
+    """Return True if an estimator should fall back to finite differences."""
+
+    if not math.isfinite(value) or not math.isfinite(half_width_abs):
+        return True
+    if price < 0.5:
+        return False
+    magnitude = abs(value)
+    if magnitude < 1e-12:
+        return half_width_abs > 1e-6
+    return half_width_abs > threshold * magnitude
+
+
+def guard_against_pathologies(arrays: Iterable[np.ndarray]) -> bool:
+    """Check that all arrays contain finite values and no NaNs/Infs."""
+
+    return all(np.isfinite(np.asarray(array, dtype=float)).all() for array in arrays)

--- a/options-pricing-engine/src/options_engine/tests/greeks/test_greeks_stability.py
+++ b/options-pricing-engine/src/options_engine/tests/greeks/test_greeks_stability.py
@@ -1,0 +1,117 @@
+"""Accuracy and stability tests for Monte Carlo greek estimators."""
+
+from __future__ import annotations
+
+import math
+from statistics import median
+from typing import Dict, List
+
+import numpy as np
+import pytest
+from numpy.random import SeedSequence
+
+import options_engine.core.pricing_models as pricing_models
+from options_engine.core.models import ExerciseStyle, MarketData, OptionContract, OptionType
+from options_engine.core.pricing_models import BlackScholesModel, MonteCarloModel
+from options_engine.tests.performance.test_pricing_benchmarks import BenchmarkScenario, _golden_grid
+
+
+@pytest.fixture(scope="module")
+def golden_grid() -> List[BenchmarkScenario]:
+    return _golden_grid()
+
+
+def _relative_error(value: float, reference: float) -> float:
+    denominator = max(abs(reference), 1e-3)
+    return abs(value - reference) / denominator
+
+
+@pytest.mark.parametrize("paths", [120_000])
+def test_mc_greeks_accuracy_and_ci(golden_grid: List[BenchmarkScenario], paths: int) -> None:
+    model = MonteCarloModel(paths=paths, antithetic=True, seed_sequence=None, use_control_variates=True)
+    bs_model = BlackScholesModel()
+
+    seed_root = SeedSequence(2024)
+    scenario_seeds = seed_root.spawn(len(golden_grid))
+
+    error_buckets: Dict[str, List[float]] = {
+        "delta": [],
+        "gamma": [],
+        "theta": [],
+        "vega": [],
+        "rho": [],
+    }
+
+    for scenario, seed in zip(golden_grid, scenario_seeds):
+        contract = scenario.contract
+        market = scenario.market
+        volatility = scenario.volatility
+
+        mc_result = model.calculate_price(contract, market, volatility, seed_sequence=seed)
+        bs_result = bs_model.calculate_price(contract, market, volatility)
+
+        ci = mc_result.ci_greeks
+        assert ci is not None, "Monte Carlo result must expose greek confidence intervals"
+        assert set(ci.keys()) == set(error_buckets.keys()), "Unexpected CI keys"
+        for stats in ci.values():
+            assert math.isfinite(stats["standard_error"])
+            assert math.isfinite(stats["half_width_abs"])
+            assert stats["standard_error"] >= 0.0
+            assert stats["half_width_abs"] >= 0.0
+
+        meta = mc_result.greeks_meta
+        assert meta is not None
+        for info in meta.values():
+            assert isinstance(info["paths_used"], int)
+            assert info["paths_used"] > 0
+            assert info["vr_pipeline"] in {"cv", "plain"}
+            assert "method" in info
+
+        error_buckets["delta"].append(_relative_error(mc_result.delta or 0.0, bs_result.delta or 0.0))
+        error_buckets["gamma"].append(_relative_error(mc_result.gamma or 0.0, bs_result.gamma or 0.0))
+        error_buckets["theta"].append(_relative_error(mc_result.theta or 0.0, bs_result.theta or 0.0))
+        error_buckets["vega"].append(_relative_error(mc_result.vega or 0.0, bs_result.vega or 0.0))
+        error_buckets["rho"].append(_relative_error(mc_result.rho or 0.0, bs_result.rho or 0.0))
+
+    assert median(error_buckets["delta"]) <= 0.015
+    assert median(error_buckets["vega"]) <= 0.015
+    assert median(error_buckets["rho"]) <= 0.015
+    assert median(error_buckets["theta"]) <= 0.015
+    assert median(error_buckets["gamma"]) <= 0.03
+
+
+def test_fd_fallback_trigger(monkeypatch: pytest.MonkeyPatch) -> None:
+    contract = OptionContract(
+        symbol="FALLBACK",
+        strike_price=100.0,
+        time_to_expiry=0.75,
+        option_type=OptionType.CALL,
+        exercise_style=ExerciseStyle.EUROPEAN,
+    )
+    market = MarketData(spot_price=100.0, risk_free_rate=0.02, dividend_yield=0.0)
+    volatility = 0.25
+
+    model = MonteCarloModel(paths=512, antithetic=False, use_control_variates=False)
+    seed = SeedSequence(77)
+
+    def _gamma_nan(*args, **kwargs):  # type: ignore[unused-argument]
+        terminal_prices = kwargs.get("terminal_prices")
+        if terminal_prices is None and len(args) >= 4:
+            terminal_prices = args[3]
+        assert terminal_prices is not None
+        return np.full_like(terminal_prices, np.nan, dtype=float)
+
+    monkeypatch.setattr(pricing_models, "pathwise_gamma", _gamma_nan)
+
+    result = model.calculate_price(contract, market, volatility, seed_sequence=seed)
+
+    assert result.greeks_meta is not None
+    gamma_meta = result.greeks_meta["gamma"]
+    assert gamma_meta["method"] == "fd"
+    assert gamma_meta["fallback"] == "fd"
+    assert gamma_meta.get("primary_method") == "pathwise_lr"
+    assert "fd_rel_error" in gamma_meta
+    assert result.ci_greeks is not None
+    gamma_ci = result.ci_greeks["gamma"]
+    assert math.isfinite(gamma_ci["standard_error"])
+    assert math.isfinite(gamma_ci["half_width_abs"])

--- a/options-pricing-engine/src/options_engine/tests/greeks/test_monotonicity_parity.py
+++ b/options-pricing-engine/src/options_engine/tests/greeks/test_monotonicity_parity.py
@@ -1,0 +1,126 @@
+"""Monotonicity, convexity, and parity checks for Monte Carlo pricing."""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Tuple
+
+import pytest
+from numpy.random import SeedSequence
+
+from options_engine.core.models import MarketData, OptionContract, OptionType
+from options_engine.core.pricing_models import MonteCarloModel
+from options_engine.tests.performance.test_pricing_benchmarks import BenchmarkScenario, _golden_grid
+
+
+@pytest.fixture(scope="module")
+def golden_grid() -> List[BenchmarkScenario]:
+    return _golden_grid()
+
+
+def _sigma_bump(volatility: float) -> float:
+    return max(1e-4 * volatility, 1e-6)
+
+
+def _tau_bump(time_to_expiry: float) -> float:
+    return max(1e-4 * time_to_expiry, 1e-7)
+
+
+def _strike_bump(strike: float) -> float:
+    return max(1e-4 * strike, 1e-4)
+
+
+@pytest.mark.parametrize("paths", [80_000])
+def test_monotonicity_convexity_parity(golden_grid: List[BenchmarkScenario], paths: int) -> None:
+    model = MonteCarloModel(paths=paths, antithetic=True, use_control_variates=True)
+
+    seed_root = SeedSequence(4096)
+    seed_pool = iter(seed_root.spawn(len(golden_grid)))
+    seed_lookup: Dict[Tuple[float, float, float], SeedSequence] = {}
+    market_lookup: Dict[Tuple[float, float, float], MarketData] = {}
+    base_results: Dict[Tuple[OptionType, float, float, float], float] = {}
+    tolerance = 5e-4
+    parity_tolerance = 2e-4
+
+    for scenario in golden_grid:
+        contract = scenario.contract
+        market = scenario.market
+        volatility = scenario.volatility
+        key = (contract.strike_price, contract.time_to_expiry, volatility)
+        seed = seed_lookup.get(key)
+        if seed is None:
+            seed = next(seed_pool)
+            seed_lookup[key] = seed
+        market_lookup[key] = market
+
+        base_result = model.calculate_price(contract, market, volatility, seed_sequence=seed)
+        base_results[(contract.option_type, *key)] = base_result.theoretical_price
+
+        # Volatility monotonicity
+        bump_sigma = _sigma_bump(volatility)
+        price_up_sigma = model.calculate_price(contract, market, volatility + bump_sigma, seed_sequence=seed)
+        price_down_sigma = model.calculate_price(
+            contract, market, max(volatility - bump_sigma, 1e-4), seed_sequence=seed
+        )
+        assert price_up_sigma.theoretical_price >= base_result.theoretical_price - tolerance
+        assert price_down_sigma.theoretical_price <= base_result.theoretical_price + tolerance
+
+        # Time monotonicity
+        bump_tau = _tau_bump(contract.time_to_expiry)
+        tau_up = contract.time_to_expiry + bump_tau
+        tau_down = max(contract.time_to_expiry - bump_tau, 1e-6)
+        contract_up = OptionContract(
+            symbol=f"{contract.symbol}_tau_up",
+            strike_price=contract.strike_price,
+            time_to_expiry=tau_up,
+            option_type=contract.option_type,
+            exercise_style=contract.exercise_style,
+        )
+        contract_down = OptionContract(
+            symbol=f"{contract.symbol}_tau_dn",
+            strike_price=contract.strike_price,
+            time_to_expiry=tau_down,
+            option_type=contract.option_type,
+            exercise_style=contract.exercise_style,
+        )
+        price_up_tau = model.calculate_price(contract_up, market, volatility, seed_sequence=seed)
+        price_down_tau = model.calculate_price(contract_down, market, volatility, seed_sequence=seed)
+        assert price_up_tau.theoretical_price >= base_result.theoretical_price - tolerance
+        assert price_down_tau.theoretical_price <= base_result.theoretical_price + tolerance
+
+        # Strike convexity
+        bump_strike = _strike_bump(contract.strike_price)
+        strike_up = contract.strike_price + bump_strike
+        strike_down = max(contract.strike_price - bump_strike, 1e-4)
+        contract_up_k = OptionContract(
+            symbol=f"{contract.symbol}_k_up",
+            strike_price=strike_up,
+            time_to_expiry=contract.time_to_expiry,
+            option_type=contract.option_type,
+            exercise_style=contract.exercise_style,
+        )
+        contract_down_k = OptionContract(
+            symbol=f"{contract.symbol}_k_dn",
+            strike_price=strike_down,
+            time_to_expiry=contract.time_to_expiry,
+            option_type=contract.option_type,
+            exercise_style=contract.exercise_style,
+        )
+        price_up_k = model.calculate_price(contract_up_k, market, volatility, seed_sequence=seed)
+        price_down_k = model.calculate_price(contract_down_k, market, volatility, seed_sequence=seed)
+        lhs = base_result.theoretical_price
+        rhs = 0.5 * (price_up_k.theoretical_price + price_down_k.theoretical_price)
+        assert lhs <= rhs + tolerance
+
+    # Put-call parity on shared keys
+    for (strike, tau, vol), market in market_lookup.items():
+        call_price = base_results.get((OptionType.CALL, strike, tau, vol))
+        put_price = base_results.get((OptionType.PUT, strike, tau, vol))
+        if call_price is None or put_price is None:
+            continue
+        forward_anchor = (
+            market.spot_price * math.exp(-market.dividend_yield * tau)
+            - strike * math.exp(-market.risk_free_rate * tau)
+        )
+        parity_gap = call_price - put_price - forward_anchor
+        assert abs(parity_gap) <= parity_tolerance


### PR DESCRIPTION
## Summary
- add Monte Carlo pathwise and likelihood-ratio Greek estimators with stability guards and finite-difference fallbacks
- expose confidence intervals and metadata on pricing results and wire estimators into the MonteCarlo model
- add accuracy, stability, and monotonicity/parity regression tests for the new estimators

## Testing
- pytest -q src/options_engine/tests/api
- pytest -q src/options_engine/tests/greeks/test_greeks_stability.py
- pytest -q src/options_engine/tests/greeks/test_monotonicity_parity.py
- pytest -q src/options_engine/tests/performance/test_pricing_benchmarks.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d62545ac408333b4fbd8ad82767cba