### PR TITLE
Add parity and Monte Carlo regression tests

### DIFF
--- a/options-pricing-engine/src/options_engine/tests/numerics/test_edges_tails.py
+++ b/options-pricing-engine/src/options_engine/tests/numerics/test_edges_tails.py
@@ -1,0 +1,36 @@
+import math
+
+from options_engine.core.models import MarketData, OptionContract, OptionType, ExerciseStyle
+from options_engine.core.pricing_models import BlackScholesModel, MonteCarloModel
+
+
+def _intrinsic(opt_type: OptionType, spot: float, strike: float, tau: float, r: float, q: float) -> float:
+    disc_r = math.exp(-r * tau)
+    disc_q = math.exp(-q * tau)
+    if opt_type is OptionType.CALL:
+        return max(disc_q * spot - disc_r * strike, 0.0)
+    return max(disc_r * strike - disc_q * spot, 0.0)
+
+
+def test_deep_itm_small_tau_near_intrinsic():
+    """Deep ITM & small-tau European call ~ intrinsic value."""
+    r, q, tau, sigma, K = 0.01, 0.0, 0.01, 0.2, 100.0
+    S = K * math.exp(5.0)
+    c = OptionContract("DEEP_ITM", K, tau, OptionType.CALL, ExerciseStyle.EUROPEAN)
+    m = MarketData(spot_price=S, risk_free_rate=r, dividend_yield=q)
+    price = BlackScholesModel().calculate_price(c, m, sigma).theoretical_price
+    intrinsic = _intrinsic(c.option_type, S, K, tau, r, q)
+    assert abs(price - intrinsic) <= 1e-3 * max(1.0, intrinsic)
+
+
+def test_mc_ci_shrinks_with_more_paths():
+    """MC standard error should decrease with more paths."""
+    r, q, tau, sigma, S, K = 0.01, 0.0, 0.5, 0.25, 100.0, 105.0
+    c = OptionContract("CI_SHRINK", K, tau, OptionType.CALL, ExerciseStyle.EUROPEAN)
+    m = MarketData(spot_price=S, risk_free_rate=r, dividend_yield=q)
+    mc_small = MonteCarloModel(paths=4000, antithetic=True)
+    mc_large = MonteCarloModel(paths=32000, antithetic=True)
+    r_small = mc_small.calculate_price(c, m, sigma)
+    r_large = mc_large.calculate_price(c, m, sigma)
+    assert r_small.standard_error is not None and r_large.standard_error is not None
+    assert r_large.standard_error < r_small.standard_error

--- a/options-pricing-engine/src/options_engine/tests/numerics/test_parity_convexity_runtime.py
+++ b/options-pricing-engine/src/options_engine/tests/numerics/test_parity_convexity_runtime.py
@@ -1,0 +1,33 @@
+import math
+
+from options_engine.core.models import MarketData, OptionContract, OptionType, ExerciseStyle
+from options_engine.core.pricing_models import BlackScholesModel
+
+
+def test_put_call_parity_identity():
+    call_c = OptionContract("PARITY", 95.0, 0.4, OptionType.CALL, ExerciseStyle.EUROPEAN)
+    put_c  = OptionContract("PARITY", 95.0, 0.4, OptionType.PUT,  ExerciseStyle.EUROPEAN)
+    m = MarketData(spot_price=100.0, risk_free_rate=0.01, dividend_yield=0.0)
+    vol = 0.2
+
+    bs = BlackScholesModel()
+    call = bs.calculate_price(call_c, m, vol).theoretical_price
+    put  = bs.calculate_price(put_c,  m, vol).theoretical_price
+
+    forward_anchor = m.spot_price * math.exp(-m.dividend_yield * call_c.time_to_expiry) \
+        - call_c.strike_price * math.exp(-m.risk_free_rate * call_c.time_to_expiry)
+    assert abs(call - put - forward_anchor) < 1e-8
+
+
+def test_convexity_in_strike_european_calls():
+    m = MarketData(spot_price=100.0, risk_free_rate=0.01, dividend_yield=0.0)
+    vol, tau, K = 0.25, 0.5, 100.0
+    dK = max(1e-3 * K, 1e-4)
+    Ks = [K - dK, K, K + dK]
+    bs = BlackScholesModel()
+    prices = []
+    for strike in Ks:
+        c = OptionContract(f"C_{strike:.4f}", strike, tau, OptionType.CALL, ExerciseStyle.EUROPEAN)
+        prices.append(bs.calculate_price(c, m, vol).theoretical_price)
+    convexity_metric = prices[0] + prices[2] - 2.0 * prices[1]
+    assert convexity_metric >= -1e-10


### PR DESCRIPTION
## Summary
- add regression tests covering Black-Scholes put-call parity and strike convexity
- add edge-case numerics and Monte Carlo variance reduction checks

## Testing
- pytest -q src/options_engine/tests/numerics
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d64bbf90988333b97b24ad619e5838