### PR TITLE
Pin dependencies and add CI badge

### DIFF
--- a/options-pricing-engine/.github/workflows/ci.yml
+++ b/options-pricing-engine/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,6 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install .[dev]
       - name: Static analysis (Bandit)
         run: bandit -r src -ll

--- a/options-pricing-engine/README.md
+++ b/options-pricing-engine/README.md
@@ -1,5 +1,7 @@
 # Options Pricing Engine
 
+![CI](https://github.com/options-pricing-engine/options-pricing-engine/actions/workflows/ci.yml/badge.svg)
+
 The Options Pricing Engine (OPE) is a FastAPI service that exposes real-time options
 valuation and risk analytics powered by Black-Scholes, binomial and Monte Carlo models.
 It is designed for production use with hardened authentication, observability and

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+pydantic==2.6.3
+numpy==1.26.4
+scipy==1.11.4
+pytest==8.1.1


### PR DESCRIPTION
## Summary
- add a pinned requirements.txt for the core runtime dependencies
- configure the CI workflow to install from the requirements file and cancel superseded runs
- surface the CI status badge in the README

## Testing
- pytest -q options-pricing-engine/src/options_engine/tests -W error::DeprecationWarning
- python options-pricing-engine/reports/generate_perf_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d658a6abb883339f8a6d08e824c18b