### PR TITLE
Fix status constant names for Starlette 0.36

### DIFF
--- a/options-pricing-engine/src/options_engine/api/codec.py
+++ b/options-pricing-engine/src/options_engine/api/codec.py
@@ -47,7 +47,7 @@ class ErrorMapping:
 
 
 VALIDATION_ERROR = ErrorMapping(status.HTTP_400_BAD_REQUEST, "invalid_request")
-UNSUPPORTED_ERROR = ErrorMapping(status.HTTP_422_UNPROCESSABLE_CONTENT, "unsupported_configuration")
+UNSUPPORTED_ERROR = ErrorMapping(status.HTTP_422_UNPROCESSABLE_ENTITY, "unsupported_configuration")
 COST_GUARD_ERROR = ErrorMapping(status.HTTP_429_TOO_MANY_REQUESTS, "cost_guard_triggered")
 NOT_FOUND_ERROR = ErrorMapping(status.HTTP_404_NOT_FOUND, "capsule_not_found")
 CONFLICT_ERROR = ErrorMapping(status.HTTP_409_CONFLICT, "build_conflict")

--- a/options-pricing-engine/src/options_engine/api/middleware.py
+++ b/options-pricing-engine/src/options_engine/api/middleware.py
@@ -76,7 +76,7 @@ class BodySizeLimitMiddleware(BaseHTTPMiddleware):
         route = request.url.path
         PAYLOAD_TOO_LARGE.labels(route=route).inc()
         response = JSONResponse(
-            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             content={"detail": "Payload too large"},
         )
         response.headers.setdefault("X-Request-ID", ensure_request_id(request))


### PR DESCRIPTION
## Summary
- replace the deprecated HTTP_422_UNPROCESSABLE_CONTENT constant with HTTP_422_UNPROCESSABLE_ENTITY
- update middleware to use HTTP_413_REQUEST_ENTITY_TOO_LARGE for payload rejections

## Testing
- PYTHONPATH=options-pricing-engine/src pytest -q --collect-only

------
https://chatgpt.com/codex/tasks/task_e_68d6706652d08333aeba85d5b0febf83