### PR TITLE
Fix Starlette TestClient compatibility

### DIFF
--- a/options-pricing-engine/src/options_engine/__init__.py
+++ b/options-pricing-engine/src/options_engine/__init__.py
@@ -1,0 +1,9 @@
+"""Core package initialisation for options_engine."""
+
+from __future__ import annotations
+
+# Import compatibility patches to ensure third-party integrations remain stable
+# with the version range exercised in the test suite.
+from . import _compat as _compat  # noqa: F401  (imported for side effects)
+
+__all__ = []

--- a/options-pricing-engine/src/options_engine/_compat.py
+++ b/options-pricing-engine/src/options_engine/_compat.py
@@ -1,0 +1,69 @@
+"""Compatibility helpers for third-party packages."""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import httpx
+
+try:  # pragma: no cover - optional dependency in runtime contexts
+    from fastapi import testclient as fastapi_testclient
+    from starlette import testclient as starlette_testclient
+except Exception:  # pragma: no cover - nothing to patch if imports fail
+    fastapi_testclient = None  # type: ignore[assignment]
+    starlette_testclient = None  # type: ignore[assignment]
+else:
+    fastapi_testclient = typing.cast(typing.Any, fastapi_testclient)
+    starlette_testclient = typing.cast(typing.Any, starlette_testclient)
+
+
+def patch_starlette_testclient() -> None:
+    """Ensure Starlette's TestClient works with the bundled httpx version."""
+
+    if starlette_testclient is None:
+        return
+
+    if "app" in inspect.signature(httpx.Client.__init__).parameters:
+        # httpx still exposes the legacy signature expected by Starlette.
+        return
+
+    def _patched_init(self, app, base_url: str = "http://testserver", raise_server_exceptions: bool = True, root_path: str = "", backend: typing.Literal["asyncio", "trio"] = "asyncio", backend_options: dict[str, typing.Any] | None = None, cookies: httpx._types.CookieTypes | None = None, headers: dict[str, str] | None = None, follow_redirects: bool = True) -> None:  # type: ignore[override]
+        self.async_backend = starlette_testclient._AsyncBackend(  # type: ignore[attr-defined]
+            backend=backend,
+            backend_options=backend_options or {},
+        )
+        if starlette_testclient._is_asgi3(app):  # type: ignore[attr-defined]
+            asgi_app = app
+        else:
+            app = typing.cast(starlette_testclient.ASGI2App, app)  # type: ignore[attr-defined]
+            asgi_app = starlette_testclient._WrapASGI2(app)  # type: ignore[attr-defined]
+        self.app = asgi_app
+        self.app_state: dict[str, typing.Any] = {}
+        transport = starlette_testclient._TestClientTransport(  # type: ignore[attr-defined]
+            self.app,
+            portal_factory=self._portal_factory,
+            raise_server_exceptions=raise_server_exceptions,
+            root_path=root_path,
+            app_state=self.app_state,
+        )
+        if headers is None:
+            headers = {}
+        headers.setdefault("user-agent", "testclient")
+        httpx.Client.__init__(  # pylint: disable=non-parent-init-called
+            self,
+            base_url=base_url,
+            headers=headers,
+            transport=transport,
+            follow_redirects=follow_redirects,
+            cookies=cookies,
+        )
+
+    starlette_testclient.TestClient.__init__ = _patched_init  # type: ignore[attr-defined]
+    if fastapi_testclient is not None:
+        fastapi_testclient.TestClient = starlette_testclient.TestClient
+
+
+patch_starlette_testclient()
+
+__all__ = ["patch_starlette_testclient"]

--- a/options-pricing-engine/src/options_engine/api/codec.py
+++ b/options-pricing-engine/src/options_engine/api/codec.py
@@ -47,7 +47,7 @@ class ErrorMapping:
 
 
 VALIDATION_ERROR = ErrorMapping(status.HTTP_400_BAD_REQUEST, "invalid_request")
-UNSUPPORTED_ERROR = ErrorMapping(status.HTTP_422_UNPROCESSABLE_CONTENT, "unsupported_configuration")
+UNSUPPORTED_ERROR = ErrorMapping(status.HTTP_422_UNPROCESSABLE_ENTITY, "unsupported_configuration")
 COST_GUARD_ERROR = ErrorMapping(status.HTTP_429_TOO_MANY_REQUESTS, "cost_guard_triggered")
 NOT_FOUND_ERROR = ErrorMapping(status.HTTP_404_NOT_FOUND, "capsule_not_found")
 CONFLICT_ERROR = ErrorMapping(status.HTTP_409_CONFLICT, "build_conflict")

--- a/options-pricing-engine/src/options_engine/api/middleware.py
+++ b/options-pricing-engine/src/options_engine/api/middleware.py
@@ -76,7 +76,7 @@ class BodySizeLimitMiddleware(BaseHTTPMiddleware):
         route = request.url.path
         PAYLOAD_TOO_LARGE.labels(route=route).inc()
         response = JSONResponse(
-            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             content={"detail": "Payload too large"},
         )
         response.headers.setdefault("X-Request-ID", ensure_request_id(request))

--- a/options-pricing-engine/src/options_engine/tests/simple_client.py
+++ b/options-pricing-engine/src/options_engine/tests/simple_client.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional
 
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import httpx
 
 
 @dataclass(slots=True)
@@ -28,23 +29,23 @@ class SimpleResponse:
 class SimpleTestClient(AbstractContextManager["SimpleTestClient"]):
     def __init__(self, app: FastAPI) -> None:
         self._app = app
+        self._client: TestClient | None = None
 
     def __enter__(self) -> "SimpleTestClient":
-        asyncio.run(self._startup())
+        self._client = TestClient(self._app)
+        self._client.__enter__()
         return self
 
     def __exit__(self, exc_type, exc, tb) -> Optional[bool]:
-        asyncio.run(self._shutdown())
+        assert self._client is not None
+        self._client.__exit__(exc_type, exc, tb)
+        self._client = None
         return None
 
-    async def _startup(self) -> None:
-        await self._app.router.startup()
-
-    async def _shutdown(self) -> None:
-        await self._app.router.shutdown()
-
     def get(self, path: str, *, headers: Optional[Mapping[str, str]] = None) -> SimpleResponse:
-        return asyncio.run(self._request("GET", path, headers=headers))
+        assert self._client is not None
+        response = self._client.get(path, headers=headers)
+        return _to_simple_response(response)
 
     def post(
         self,
@@ -55,78 +56,28 @@ class SimpleTestClient(AbstractContextManager["SimpleTestClient"]):
         content: bytes | None = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> SimpleResponse:
-        body: bytes
-        send_headers = dict(headers or {})
+        assert self._client is not None
         if json is not None:
-            body = json_dump_bytes(json)
-            send_headers.setdefault("content-type", "application/json")
+            response = self._client.post(path, json=json, headers=headers)
         elif content is not None:
-            body = content
+            response = self._client.post(path, content=content, headers=headers)
         elif data is not None:
-            body = json_dump_bytes(data)
-            send_headers.setdefault("content-type", "application/json")
+            response = self._client.post(path, json=data, headers=headers)
         else:
-            body = b""
-        return asyncio.run(self._request("POST", path, headers=send_headers, body=body))
-
-    async def _request(
-        self,
-        method: str,
-        path: str,
-        *,
-        headers: Optional[Mapping[str, str]] = None,
-        body: bytes = b"",
-    ) -> SimpleResponse:
-        header_items = dict(headers or {})
-        header_items.setdefault("host", "testserver")
-        header_items.setdefault("content-length", str(len(body)))
-        scope = {
-            "type": "http",
-            "http_version": "1.1",
-            "method": method,
-            "path": path,
-            "raw_path": path.encode(),
-            "query_string": b"",
-            "headers": [(k.lower().encode(), v.encode()) for k, v in header_items.items()],
-            "client": ("testclient", 0),
-        }
-
-        response_headers: list[tuple[bytes, bytes]] = []
-        response_status = 500
-        body_parts: list[bytes] = []
-        body_sent = False
-
-        async def receive() -> Mapping[str, Any]:
-            nonlocal body_sent
-            if body_sent:
-                await asyncio.sleep(0)
-                return {"type": "http.disconnect"}
-            body_sent = True
-            return {"type": "http.request", "body": body, "more_body": False}
-
-        async def send(message: Mapping[str, Any]) -> None:
-            nonlocal response_status, response_headers
-            if message["type"] == "http.response.start":
-                response_status = message["status"]
-                response_headers = list(message.get("headers", []))
-            elif message["type"] == "http.response.body":
-                body_parts.append(message.get("body", b""))
-
-        await self._app(scope, receive, send)
-        headers_dict: Dict[str, str] = {}
-        for raw_key, raw_value in response_headers:
-            key = raw_key.decode()
-            value = raw_value.decode()
-            headers_dict[key] = value
-            canonical = "-".join(part.capitalize() for part in key.split("-"))
-            headers_dict.setdefault(canonical, value)
-            if key.lower() == "x-request-id":
-                headers_dict.setdefault("X-Request-ID", value)
-        return SimpleResponse(status_code=response_status, headers=headers_dict, content=b"".join(body_parts))
+            response = self._client.post(path, headers=headers)
+        return _to_simple_response(response)
 
 
-def json_dump_bytes(payload: Any) -> bytes:
-    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode()
+def _to_simple_response(response: httpx.Response) -> SimpleResponse:
+    raw_headers = dict(response.headers)
+    headers: Dict[str, str] = {}
+    for key, value in raw_headers.items():
+        headers[key] = value
+        canonical = "-".join(part.capitalize() for part in key.split("-"))
+        headers.setdefault(canonical, value)
+        if key.lower() == "x-request-id":
+            headers.setdefault("X-Request-ID", value)
+    return SimpleResponse(status_code=response.status_code, headers=headers, content=response.content)
 
 
 __all__ = ["SimpleTestClient", "SimpleResponse"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pydantic==2.6.3
 numpy==1.26.4
 scipy==1.11.4
 pytest==8.1.1
+starlette==0.36.3
+anyio<5


### PR DESCRIPTION
## Summary
- add a compatibility shim so Starlette's TestClient works with the httpx version bundled in the environment
- rework the SimpleTestClient used in integration tests to delegate to FastAPI's TestClient for consistent responses
- pin starlette and anyio in requirements to match the versions exercised by the suite

## Testing
- PYTHONPATH=options-pricing-engine/src MC_ENABLE_QMC=0 \
  pytest -q options-pricing-engine/src/options_engine/tests -W error::DeprecationWarning

------
https://chatgpt.com/codex/tasks/task_e_68d6706652d08333aeba85d5b0febf83