### PR TITLE
Add gitignore entries for test artifacts

### DIFF
--- a/options-pricing-engine/.gitignore
+++ b/options-pricing-engine/.gitignore
@@ -1,0 +1,21 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+
+# Distribution / packaging
+*.egg-info/
+build/
+dist/
+
+# Virtual environments
+.env
+.venv
+
+# Test and coverage reports
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Project-specific generated files
+src/options_engine/tests/performance/benchmarks_report.json


### PR DESCRIPTION
## Summary
- add a project-level .gitignore to filter Python caches and pytest output
- ignore the performance benchmark report emitted during the test suite so reruns leave the repo clean

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68658e8248333a7ca9f3d2f958a6e