### PR TITLE
Fix test suite warnings and stabilize custom ASGI client

### DIFF
--- a/options-pricing-engine/.gitignore
+++ b/options-pricing-engine/.gitignore
@@ -1,0 +1,21 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+
+# Distribution / packaging
+*.egg-info/
+build/
+dist/
+
+# Virtual environments
+.env
+.venv
+
+# Test and coverage reports
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Project-specific generated files
+src/options_engine/tests/performance/benchmarks_report.json

--- a/options-pricing-engine/src/options_engine/_compat.py
+++ b/options-pricing-engine/src/options_engine/_compat.py
@@ -3,9 +3,29 @@
 from __future__ import annotations
 
 import inspect
+import sys
 import typing
+from calendar import timegm
+from datetime import UTC, datetime
 
 import httpx
+
+try:  # pragma: no cover - optional dependency in runtime contexts
+    import python_multipart
+except ModuleNotFoundError:  # pragma: no cover - dependency may be missing in minimal installs
+    python_multipart = None  # type: ignore[assignment]
+else:  # pragma: no cover - executed when python-multipart is available
+    # Starlette still imports the legacy ``multipart`` package name which now emits a
+    # PendingDeprecationWarning.  Pre-register the modern module to keep imports quiet.
+    sys.modules.setdefault("multipart", python_multipart)
+
+try:  # pragma: no cover - optional dependency in runtime contexts
+    from jose import jwt as jose_jwt
+    from jose.exceptions import ExpiredSignatureError, JWTClaimsError
+except Exception:  # pragma: no cover - skip JWT patches when python-jose is unavailable
+    jose_jwt = None  # type: ignore[assignment]
+else:
+    jose_jwt = typing.cast(typing.Any, jose_jwt)
 
 try:  # pragma: no cover - optional dependency in runtime contexts
     from fastapi import testclient as fastapi_testclient
@@ -16,6 +36,43 @@ except Exception:  # pragma: no cover - nothing to patch if imports fail
 else:
     fastapi_testclient = typing.cast(typing.Any, fastapi_testclient)
     starlette_testclient = typing.cast(typing.Any, starlette_testclient)
+
+
+def _patch_jose_time_validation() -> None:
+    """Replace python-jose datetime helpers with timezone-aware implementations."""
+
+    if jose_jwt is None:  # pragma: no cover - environment without python-jose
+        return
+
+    def _aware_now_seconds() -> int:
+        """Return the current UTC timestamp using timezone-aware datetimes."""
+
+        return timegm(datetime.now(UTC).utctimetuple())
+
+    def _patched_validate_nbf(claims, leeway=0):  # type: ignore[override]
+        if "nbf" not in claims:
+            return
+        try:
+            nbf = int(claims["nbf"])
+        except ValueError:
+            raise JWTClaimsError("Not Before claim (nbf) must be an integer.")
+        now = _aware_now_seconds()
+        if nbf > (now + leeway):
+            raise JWTClaimsError("The token is not yet valid (nbf)")
+
+    def _patched_validate_exp(claims, leeway=0):  # type: ignore[override]
+        if "exp" not in claims:
+            return
+        try:
+            exp = int(claims["exp"])
+        except ValueError:
+            raise JWTClaimsError("Expiration Time claim (exp) must be an integer.")
+        now = _aware_now_seconds()
+        if exp < (now - leeway):
+            raise ExpiredSignatureError("Signature has expired.")
+
+    jose_jwt._validate_nbf = _patched_validate_nbf  # type: ignore[attr-defined]
+    jose_jwt._validate_exp = _patched_validate_exp  # type: ignore[attr-defined]
 
 
 def patch_starlette_testclient() -> None:
@@ -65,5 +122,6 @@ def patch_starlette_testclient() -> None:
 
 
 patch_starlette_testclient()
+_patch_jose_time_validation()
 
 __all__ = ["patch_starlette_testclient"]

--- a/options-pricing-engine/src/options_engine/tests/api/test_api_american.py
+++ b/options-pricing-engine/src/options_engine/tests/api/test_api_american.py
@@ -1,20 +1,7 @@
-import pytest
-from fastapi.testclient import TestClient
-
-from options_engine.api.server import create_app
-from options_engine.tests.utils import make_token
+from options_engine.tests.simple_client import SimpleTestClient
 
 
-@pytest.fixture()
-def client() -> TestClient:
-    app = create_app()
-    token = make_token(scopes=["pricing:read"])
-    client = TestClient(app)
-    client.headers.update({"Authorization": f"Bearer {token}"})
-    return client
-
-
-def test_quote_american_routes_to_lsmc(client: TestClient) -> None:
+def test_quote_american_routes_to_lsmc(client: SimpleTestClient) -> None:
     payload = {
         "contract": {
             "symbol": "SPY",

--- a/options-pricing-engine/src/options_engine/tests/security/test_auth.py
+++ b/options-pricing-engine/src/options_engine/tests/security/test_auth.py
@@ -5,11 +5,11 @@ import json
 import time
 
 import pytest
-from fastapi.testclient import TestClient
 
 from options_engine.api.config import get_settings
 from options_engine.api.security import _get_authenticator
 from options_engine.api.server import build_app
+from options_engine.tests.simple_client import SimpleTestClient
 
 DEV_SECRET = "dev-secret-value-at-least-32-bytes!!!"
 
@@ -70,40 +70,39 @@ def _quote_body() -> dict:
 
 def test_missing_token_rejected():
     app = build_app()
-    client = TestClient(app)
-    response = client.post("/quote", json={})
+    with SimpleTestClient(app) as client:
+        response = client.post("/quote", json={})
     assert response.status_code in (401, 403)
 
 
 def test_scope_enforced():
     app = build_app()
-    client = TestClient(app)
     token = _token(scopes="market-data:write")
-    response = client.post(
-        "/quote",
-        headers={"Authorization": f"Bearer {token}"},
-        json={},
-    )
+    with SimpleTestClient(app) as client:
+        response = client.post(
+            "/quote",
+            headers={"Authorization": f"Bearer {token}"},
+            json={},
+        )
     assert response.status_code in (401, 403)
 
 
 def test_valid_token_allows():
     app = build_app()
-    client = TestClient(app)
     token = _token(scopes="pricing:read extra:ok")
     body = _quote_body()
-    response = client.post(
-        "/quote",
-        headers={"Authorization": f"Bearer {token}"},
-        json=body,
-    )
+    with SimpleTestClient(app) as client:
+        response = client.post(
+            "/quote",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
     assert response.status_code == 200
     assert "theoretical_price" in response.json()
 
 
 def test_expired_token_rejected():
     app = build_app()
-    client = TestClient(app)
     now = int(time.time())
     payload = {
         "iss": "https://issuer.dev",
@@ -115,9 +114,10 @@ def test_expired_token_rejected():
         "scope": "pricing:read",
     }
     token = _hs256(payload, DEV_SECRET)
-    response = client.post(
-        "/quote",
-        headers={"Authorization": f"Bearer {token}"},
-        json=_quote_body(),
-    )
+    with SimpleTestClient(app) as client:
+        response = client.post(
+            "/quote",
+            headers={"Authorization": f"Bearer {token}"},
+            json=_quote_body(),
+        )
     assert response.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- alias python-multipart to silence PendingDeprecationWarning and patch python-jose time validation to use timezone-aware timestamps
- harden the custom SimpleTestClient’s ASGI scope/receive loop and reuse it across API, integration, and security tests to avoid httpx deprecation warnings
- update integration tests to use SimpleTestClient for rate limiting/body size scenarios without deprecated httpx parameters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68658e8248333a7ca9f3d2f958a6e